### PR TITLE
fix(runtime): stop closing s.Events in Stop; use Base.StopWatcher

### DIFF
--- a/runtime.go
+++ b/runtime.go
@@ -486,15 +486,12 @@ func (s *Runtime) Stop(ctx context.Context, req *runtimev0.StopRequest) (*runtim
 		s.Wool.Trace("runner stopped")
 	}
 
-	// Stop the file watcher to prevent CPU spin on orphaned processes
-	if s.Watcher != nil {
-		s.Watcher.Pause()
-	}
-	// Close events channel to unblock the handler goroutine
-	if s.Events != nil {
-		close(s.Events)
-		s.Events = nil
-	}
+	// Tear down the file watcher. Cancelling it makes its Start goroutine run
+	// `defer close(Events)` — the single close of the events channel, which also
+	// unblocks the debounce handler. Stop must NOT close s.Events itself: that
+	// second close raced the watcher goroutine into a "close of closed channel"
+	// panic (crashing the agent on every shutdown, including Ctrl-C).
+	s.Base.StopWatcher()
 
 	s.Wool.Trace("base stopped")
 	return s.Base.Runtime.StopResponse()


### PR DESCRIPTION
**Draft — blocked on the next core release + dep bump.** Do not merge until `go.mod` is pinned (`codefly agent deps --pin <ver>`) to a core version containing `services.Base.StopWatcher` (codefly-dev/core#49, merged). Builds locally today via the shared `go.work`.

## Fix

`s.Events` is closed by `code.Watcher.Start`'s `defer close` — the sole sender and rightful closer. `Runtime.Stop` also closed it, racing that goroutine into `panic: close of closed channel`. When the loser was the watcher goroutine (no gRPC interceptor around it) the panic escaped and crashed the agent with **exit status 2** on every teardown, including Ctrl-C. Stop now calls `s.Base.StopWatcher()` instead of closing the channel itself.

Companion PRs: codefly-dev/core#49 (merged), service-go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)