### PR TITLE
Wire grpc.health.v1 and a /healthz gateway route into generated services (#3)

### DIFF
--- a/base/code/pkg/adapters/grpc_gen.go
+++ b/base/code/pkg/adapters/grpc_gen.go
@@ -25,6 +25,8 @@ import (
 
 	codefly "github.com/codefly-dev/sdk-go"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	"google.golang.org/grpc/health/grpc_health_v1"
 )
 
 var validator protovalidate.Validator
@@ -70,6 +72,7 @@ type GrpcServer struct {
 	gen.UnimplementedWebServiceServer
 	configuration *Configuration
 	gRPC          *grpc.Server
+	health        *health.Server
 	validator     protovalidate.Validator
 }
 
@@ -80,9 +83,15 @@ func NewGrpServer(c *Configuration) (*GrpcServer, error) {
 		return nil, fmt.Errorf("failed to create validator: %w", err)
 	}
 
+	healthServer := health.NewServer()
+	grpc_health_v1.RegisterHealthServer(grpcServer, healthServer)
+	healthServer.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
+	healthServer.SetServingStatus(gen.WebService_ServiceDesc.ServiceName, grpc_health_v1.HealthCheckResponse_SERVING)
+
 	s := GrpcServer{
 		configuration: c,
 		gRPC:          grpcServer,
+		health:        healthServer,
 		validator:     v,
 	}
 	service := gen.WebServiceServer(&s)

--- a/base/code/pkg/adapters/rest_gen.go
+++ b/base/code/pkg/adapters/rest_gen.go
@@ -24,6 +24,7 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health/grpc_health_v1"
 )
 
 type RestServer struct {
@@ -75,6 +76,25 @@ func (s *RestServer) Run(ctx context.Context) error {
 		if err := p.RegisterREST(ctx, gwMux, fmt.Sprintf("0.0.0.0:%d", s.config.EndpointGrpcPort), opts); err != nil {
 			return fmt.Errorf("plugin %s REST registration failed: %w", p.Name(), err)
 		}
+	}
+
+	// Expose the gRPC health check as /healthz for HTTP probes
+	healthConn, err := grpc.NewClient(fmt.Sprintf("0.0.0.0:%d", s.config.EndpointGrpcPort), opts...)
+	if err != nil {
+		return fmt.Errorf("failed to create health client connection: %w", err)
+	}
+	healthClient := grpc_health_v1.NewHealthClient(healthConn)
+	err = gwMux.HandlePath(http.MethodGet, "/healthz", func(w http.ResponseWriter, r *http.Request, _ map[string]string) {
+		resp, err := healthClient.Check(r.Context(), &grpc_health_v1.HealthCheckRequest{})
+		if err != nil || resp.GetStatus() != grpc_health_v1.HealthCheckResponse_SERVING {
+			http.Error(w, `{"status":"NOT_SERVING"}`, http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"SERVING"}`))
+	})
+	if err != nil {
+		return fmt.Errorf("failed to register health check handler: %w", err)
 	}
 
 	// Wrap your mux with the CORS handler

--- a/base/code/pkg/adapters/server_gen.go
+++ b/base/code/pkg/adapters/server_gen.go
@@ -76,5 +76,6 @@ func (server *Server) Start(ctx context.Context) error {
 
 func (server *Server) Stop() {
 	fmt.Println("Stopping server...")
+	server.grpc.health.Shutdown()
 	server.grpc.gRPC.GracefulStop()
 }

--- a/go.sum
+++ b/go.sum
@@ -37,12 +37,12 @@ github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJ
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
-github.com/codefly-dev/core v0.2.19 h1:J2nffMEzmr9FHkf1lh/2gNPbjJFYjpQHro3niejrv04=
-github.com/codefly-dev/core v0.2.19/go.mod h1:78gNY4qIlPnj08Fe8X5WwXWtqjTvU4MelJlOYTJq/5s=
+github.com/codefly-dev/core v0.2.24 h1:1CRaWbVIQXnkW+lX3U4kgdYUfnqdODjUzNGta/ECrCM=
+github.com/codefly-dev/core v0.2.24/go.mod h1:78gNY4qIlPnj08Fe8X5WwXWtqjTvU4MelJlOYTJq/5s=
 github.com/codefly-dev/gortk v0.2.0 h1:7bOlS5valYz2zil+fZctQNcPCYBcPj86abcw9N8h1hQ=
 github.com/codefly-dev/gortk v0.2.0/go.mod h1:dDWUMFgAP063OCGhTEpV7FFUj9+zTcxxO/nV80VKEwg=
-github.com/codefly-dev/service-go v0.0.10 h1:8hdaRF5oazuxgTagkBR1rjVnqnmLkM+cqlMY856gLlQ=
-github.com/codefly-dev/service-go v0.0.10/go.mod h1:pwpB8tifseXi+SL6LRW7GkQUSlFm07Ck2fEVGMiwfKk=
+github.com/codefly-dev/service-go v0.0.15 h1:Dz0F8aHNRMqyu94NTKGBXtaIpJhe0zf4APtBmRz8P44=
+github.com/codefly-dev/service-go v0.0.15/go.mod h1:gxcRjUhmboQJVZmkOd27CrML8UPAhp47cPFA0P51l+M=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=
 github.com/containerd/errdefs v1.0.0/go.mod h1:+YBYIdtsnF4Iw6nWZhJcqGSg/dwvV7tyJ/kCkyJ2k+M=
 github.com/containerd/errdefs/pkg v0.3.0 h1:9IKJ06FvyNlexW690DXuQNx2KA2cUJXx151Xdx3ZPPE=

--- a/main_test.go
+++ b/main_test.go
@@ -221,6 +221,15 @@ func testRun(t *testing.T, runtime *Runtime, ctx context.Context, identity *base
 		version, ok := data["version"].(string)
 		require.True(t, ok)
 		require.Equal(t, identity.Version, version)
+
+		// The gateway proxies grpc.health.v1 as /healthz
+		healthResponse, err := client.Get(fmt.Sprintf("%s/healthz", instance.Address))
+		if err != nil {
+			tries++
+			continue
+		}
+		healthResponse.Body.Close()
+		require.Equal(t, http.StatusOK, healthResponse.StatusCode)
 		return
 	}
 }

--- a/proto_template_test.go
+++ b/proto_template_test.go
@@ -122,6 +122,45 @@ func TestGeneratedServiceOmitsRESTImplementationWhenDisabled(t *testing.T) {
 	}
 }
 
+// TestGeneratedServiceRegistersHealthChecks keeps the grpc.health.v1 service
+// and the /healthz gateway route that the kustomize deployment probes target.
+func TestGeneratedServiceRegistersHealthChecks(t *testing.T) {
+	grpcTemplate, err := factoryFS.ReadFile("templates/factory/code/pkg/adapters/grpc_gen.go.tmpl")
+	if err != nil {
+		t.Fatalf("read gRPC adapter template: %v", err)
+	}
+	for _, want := range []string{
+		"health.NewServer()",
+		"grpc_health_v1.RegisterHealthServer",
+		`SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)`,
+	} {
+		if !strings.Contains(string(grpcTemplate), want) {
+			t.Errorf("gRPC adapter template does not contain %q", want)
+		}
+	}
+
+	serverTemplate, err := factoryFS.ReadFile("templates/factory/code/pkg/adapters/server_gen.go.tmpl")
+	if err != nil {
+		t.Fatalf("read server adapter template: %v", err)
+	}
+	if !strings.Contains(string(serverTemplate), "server.grpc.health.Shutdown()") {
+		t.Error("server adapter does not flip health to NOT_SERVING on shutdown")
+	}
+
+	restTemplate, err := factoryFS.ReadFile("templates/factory/code/pkg/adapters/rest_gen.go.tmpl")
+	if err != nil {
+		t.Fatalf("read REST adapter template: %v", err)
+	}
+	for _, want := range []string{
+		`HandlePath(http.MethodGet, "/healthz"`,
+		"grpc_health_v1.NewHealthClient",
+	} {
+		if !strings.Contains(string(restTemplate), want) {
+			t.Errorf("REST adapter template does not contain %q", want)
+		}
+	}
+}
+
 func TestGeneratedScaffoldSelectPreservesUserOwnedFiles(t *testing.T) {
 	selectGenerated := generatedScaffoldSelect()
 	for _, name := range []string{"code", "pkg", "adapters", "plugins", "main.go.tmpl", "grpc_gen.go.tmpl", "registry_gen.go.tmpl"} {

--- a/templates/factory/code/pkg/adapters/grpc_gen.go.tmpl
+++ b/templates/factory/code/pkg/adapters/grpc_gen.go.tmpl
@@ -25,6 +25,8 @@ import (
 
 	codefly "github.com/codefly-dev/sdk-go"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	"google.golang.org/grpc/health/grpc_health_v1"
 )
 
 var validator protovalidate.Validator
@@ -70,6 +72,7 @@ type GrpcServer struct {
 	gen.Unimplemented{{ .Service.Name.Title }}ServiceServer
 	configuration *Configuration
 	gRPC          *grpc.Server
+	health        *health.Server
 	validator     protovalidate.Validator
 }
 
@@ -80,9 +83,15 @@ func NewGrpServer(c *Configuration) (*GrpcServer, error) {
 		return nil, fmt.Errorf("failed to create validator: %w", err)
 	}
 
+	healthServer := health.NewServer()
+	grpc_health_v1.RegisterHealthServer(grpcServer, healthServer)
+	healthServer.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
+	healthServer.SetServingStatus(gen.{{ .Service.Name.Title }}Service_ServiceDesc.ServiceName, grpc_health_v1.HealthCheckResponse_SERVING)
+
 	s := GrpcServer{
 		configuration: c,
 		gRPC:          grpcServer,
+		health:        healthServer,
 		validator:     v,
 	}
 	service := gen.{{ .Service.Name.Title }}ServiceServer(&s)

--- a/templates/factory/code/pkg/adapters/rest_gen.go.tmpl
+++ b/templates/factory/code/pkg/adapters/rest_gen.go.tmpl
@@ -26,6 +26,7 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health/grpc_health_v1"
 )
 
 type RestServer struct {
@@ -77,6 +78,25 @@ func (s *RestServer) Run(ctx context.Context) error {
 		if err := p.RegisterREST(ctx, gwMux, fmt.Sprintf("0.0.0.0:%d", s.config.EndpointGrpcPort), opts); err != nil {
 			return fmt.Errorf("plugin %s REST registration failed: %w", p.Name(), err)
 		}
+	}
+
+	// Expose the gRPC health check as /healthz for HTTP probes
+	healthConn, err := grpc.NewClient(fmt.Sprintf("0.0.0.0:%d", s.config.EndpointGrpcPort), opts...)
+	if err != nil {
+		return fmt.Errorf("failed to create health client connection: %w", err)
+	}
+	healthClient := grpc_health_v1.NewHealthClient(healthConn)
+	err = gwMux.HandlePath(http.MethodGet, "/healthz", func(w http.ResponseWriter, r *http.Request, _ map[string]string) {
+		resp, err := healthClient.Check(r.Context(), &grpc_health_v1.HealthCheckRequest{})
+		if err != nil || resp.GetStatus() != grpc_health_v1.HealthCheckResponse_SERVING {
+			http.Error(w, `{"status":"NOT_SERVING"}`, http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"SERVING"}`))
+	})
+	if err != nil {
+		return fmt.Errorf("failed to register health check handler: %w", err)
 	}
 
 	// Wrap your mux with the CORS handler

--- a/templates/factory/code/pkg/adapters/server_gen.go.tmpl
+++ b/templates/factory/code/pkg/adapters/server_gen.go.tmpl
@@ -84,5 +84,6 @@ func (server *Server) Start(ctx context.Context) error {
 
 func (server *Server) Stop() {
 	fmt.Println("Stopping server...")
+	server.grpc.health.Shutdown()
 	server.grpc.gRPC.GracefulStop()
 }


### PR DESCRIPTION
Closes #3.

## Summary
- Generated services now register `grpc.health.v1` via `health.NewServer()` at gRPC server construction, marking both the overall server (`""`) and the concrete service as `SERVING`, and flipping to `NOT_SERVING` on graceful shutdown.
- The gRPC-Gateway exposes the health service as `GET /healthz`, which is the exact path the kustomize deployment template's startup/readiness/liveness probes already target — until now that convention was documented in the deployment template but never implemented by the scaffold.
- Applied identically to `base/code` and the factory templates so both scaffold paths stay in sync.

Also repairs the root `go.sum`, which was stale against `go.mod` (core v0.2.24 / service-go v0.0.15 entries missing), so `go build ./...` works again; `go mod tidy` produced no other changes. Note that `base/code` still does not build standalone — its `go.mod` pins `core v0.2.21`, a tag that doesn't exist upstream; pre-existing and untouched here.

## Test plan
- [x] `go build ./...` and `go vet ./...`
- [x] New `TestGeneratedServiceRegistersHealthChecks` guards the health registration, shutdown transition, and `/healthz` route in the factory templates
- [x] `TestCreateToRunNative` (extended): scaffolds a service from the templates, compiles and runs it, and now asserts `GET /healthz` returns 200 alongside the existing `/version` check
- [x] Existing template/deployment/settings unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added gRPC health-check reporting for service readiness.
  - Added a REST `GET /healthz` endpoint returning `200` when serving and `503` when unavailable.
  - Health status now transitions appropriately during server shutdown.

- **Tests**
  - Added coverage validating health-check registration, status reporting, REST responses, and shutdown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->