### PR TITLE
chore: disable CodeRabbit auto-review (review on demand)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,9 @@
+# CodeRabbit configuration
+# Docs: https://docs.coderabbit.ai/reference/configuration
+#
+# Automatic reviews are disabled: CodeRabbit will not review pull requests
+# on its own. Request a review on demand by commenting on a PR:
+#   @coderabbitai review
+reviews:
+  auto_review:
+    enabled: false


### PR DESCRIPTION
Adds `.coderabbit.yaml` disabling CodeRabbit's automatic per-PR reviews.

## Why
CodeRabbit currently auto-reviews every PR. This makes reviews opt-in instead.

## How to review a PR after this
Comment on any PR:

```
@coderabbitai review
```

## Config
```yaml
reviews:
  auto_review:
    enabled: false
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)