### PR TITLE
Migrate release to shared go-service-release workflow (#13)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,21 +1,15 @@
 name: ci
+
 on:
   push:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
-      - name: Build
-        run: go build ./...
-      - name: Vet
-        run: go vet ./...
+  ci:
+    uses: codefly-dev/core/.github/workflows/go-service-ci.yml@main

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   release:
-    uses: codefly-dev/.github/.github/workflows/go-service-release.yml@main
+    uses: codefly-dev/core/.github/workflows/go-service-release.yml@main
     secrets: inherit

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -6,19 +6,27 @@ on:
       - 'v*'
 
 jobs:
-  goreleaser:
+  test:
     runs-on: ubuntu-latest
     steps:
-      - name: Check out code
-        uses: actions/checkout@v3
-
-      - name: Set up Go
-        uses: actions/setup-go@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
-
+          go-version-file: 'go.mod'
       - name: test
         run: go test -v ./...
+
+  goreleaser:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -6,32 +6,6 @@ on:
       - 'v*'
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
-      - name: test
-        run: go test -v ./...
-
-  goreleaser:
-    needs: test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
-
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v3
-        with:
-          version: latest
-          args: release --clean
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+  release:
+    uses: codefly-dev/.github/.github/workflows/go-service-release.yml@main
+    secrets: inherit


### PR DESCRIPTION
Closes #13.

## Summary
- Tag releases here never published assets, so `codefly ci run` (which in CI can only fetch agents from GitHub release assets) 404s — turning module-saas-starter CI red.
- Root cause: `releaser.yml` ran `go test -v ./...` and GoReleaser in one workspace. The lifecycle tests leave a read-only Go module cache under `.codefly/` (gitignored, so GoReleaser's clean-tree check passes); GoReleaser's default archive step then tree-walks for `license*`/`readme*`, hits the cache's unreadable dirs, and aborts with `globbing failed for pattern license*: … permission denied` — publishing nothing.
- Fix: run GoReleaser from a **fresh checkout**, split from the test job. This PR does that by calling the new shared reusable workflow (`codefly-dev/.github` → `go-service-release.yml`) rather than inlining it, so the fix is uniform across all services.

## Depends on
- codefly-dev/.github#2 (the reusable workflow) — **merge that first**; this caller references it `@main`.

## Investigation notes
- The `v0.1.11` run failed earlier at the test step: `go.mod` was bumped to `core v0.2.24` without updating `go.sum`. That drift is already resolved on `main`; `go test ./...` is green at HEAD (67s, docker matrix included).
- `GH_PAT` is valid — the `v0.1.6` run authenticated and built all binaries, failing only at the archive glob above.
- Reproduced the failure locally with `goreleaser release --snapshot` against a workspace containing a read-only `.codefly` cache, and confirmed a clean checkout produces all three archives (`service-go-grpc_<ver>_{linux_amd64,darwin_amd64,darwin_arm64}.tar.gz`).

## Follow-up (release trigger — not done here)
No `v0.1.12` tag exists yet. After this + the reusable workflow merge, cut it to publish assets:
```
git tag v0.1.12 <merge-commit> && git push origin v0.1.12
```

## Test plan
- [x] `go test ./...` passes at HEAD (docker matrix included)
- [x] `goreleaser release --snapshot --clean --skip=publish` on a clean tree produces the linux_amd64 + darwin archives
- [x] Reproduced the `globbing failed … permission denied` archive failure with a `.codefly` cache present; confirmed it does not occur from a fresh checkout
- [x] Caller workflow is valid YAML
- [ ] After merge: push `v0.1.12` and confirm `gh release view v0.1.12 --json assets` lists the archives