### PR TITLE
Run goimports over generated Go during sync (#15)

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -4,9 +4,12 @@ import (
 	"bytes"
 	"context"
 	"embed"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
+
+	"golang.org/x/tools/imports"
 
 	"github.com/bufbuild/protocompile/ast"
 	"github.com/bufbuild/protocompile/parser"
@@ -194,6 +197,16 @@ func (s *Builder) Sync(ctx context.Context, request *builderv0.SyncRequest) (*bu
 		}
 	}
 
+	// buf and the language plugins emit Go that the agent's own lint
+	// (corecode.GoCodeServer, golang.org/x/tools/imports) can still flag as
+	// needing a safe fix, because the two paths pinned different goimports
+	// versions. Run the exact function the lint runs — same x/tools version, so
+	// byte-identical output — over the staged tree so generated code is
+	// lint-clean and sync-drift and lint agree on it.
+	if err := formatStagedGo(transaction.StageRoot()); err != nil {
+		return s.Base.Builder.SyncError(err)
+	}
+
 	changed, err := transaction.ChangedFiles()
 	if err != nil {
 		return s.Base.Builder.SyncError(err)
@@ -209,6 +222,39 @@ func (s *Builder) Sync(ctx context.Context, request *builderv0.SyncRequest) (*bu
 	}
 	response.ChangedFiles = changed
 	return response, nil
+}
+
+// formatStagedGo rewrites every staged .go file through the same goimports pass
+// the lint uses to decide a file "needs Fix". Applied to the generated output
+// before it is compared and swapped in, so the code the agent produces already
+// satisfies the agent's own formatting check. imports.Process leaves an
+// already-clean file untouched, so this is idempotent and keeps sync
+// deterministic.
+func formatStagedGo(root string) error {
+	return filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() || filepath.Ext(path) != ".go" {
+			return nil
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		fixed, err := imports.Process(path, content, &imports.Options{Comments: true})
+		if err != nil {
+			return fmt.Errorf("goimports %q: %w", path, err)
+		}
+		if bytes.Equal(content, fixed) {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(path, fixed, info.Mode().Perm())
+	})
 }
 
 // generatedScaffoldSelect traverses only the directories required to reach

--- a/builder.go
+++ b/builder.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"embed"
-	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -230,21 +229,33 @@ func (s *Builder) Sync(ctx context.Context, request *builderv0.SyncRequest) (*bu
 // satisfies the agent's own formatting check. imports.Process leaves an
 // already-clean file untouched, so this is idempotent and keeps sync
 // deterministic.
+//
+// Formatting at the stage path is a valid stand-in for the lint's later run at
+// the real path because imports.Process is path-independent for this input:
+// with no LocalPrefix and no missing/unused imports — always true of generated
+// protobuf — it reduces to gofmt plus a std/non-std import sort, neither of
+// which depends on the file's location.
 func formatStagedGo(root string) error {
 	return filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
 		}
-		if entry.IsDir() || filepath.Ext(path) != ".go" {
+		// Only regular .go files: a symlink ending in .go would be dereferenced
+		// by the os.WriteFile below and truncate its target, possibly outside the
+		// staged tree.
+		if !entry.Type().IsRegular() || filepath.Ext(path) != ".go" {
 			return nil
 		}
 		content, err := os.ReadFile(path)
 		if err != nil {
 			return err
 		}
+		// A file goimports cannot parse is left untouched rather than failing the
+		// whole sync — the lint reports it separately, and sync has no more to add
+		// than it did before this pass existed.
 		fixed, err := imports.Process(path, content, &imports.Options{Comments: true})
 		if err != nil {
-			return fmt.Errorf("goimports %q: %w", path, err)
+			return nil
 		}
 		if bytes.Equal(content, fixed) {
 			return nil

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/codefly-dev/core v0.2.24
 	github.com/codefly-dev/service-go v0.0.15
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/tools v0.44.0
 	google.golang.org/grpc v1.80.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -111,7 +112,6 @@ require (
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/term v0.43.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
-	golang.org/x/tools v0.44.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260420184626-e10c466a9529 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260420184626-e10c466a9529 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect

--- a/sync_transaction_test.go
+++ b/sync_transaction_test.go
@@ -6,7 +6,47 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"golang.org/x/tools/imports"
 )
+
+// TestFormatStagedGoMatchesLint proves that generation and lint agree: after
+// formatStagedGo rewrites a staged .go file, the exact goimports pass the lint
+// runs reports it clean, and a second pass is a no-op.
+func TestFormatStagedGoMatchesLint(t *testing.T) {
+	stage := t.TempDir()
+	unformatted := "package sample\n\nimport \"strings\"\nimport \"fmt\"\n\nfunc Use()  string {return fmt.Sprint(strings.ToUpper(\"x\"))}\n"
+	goPath := filepath.Join(stage, "gen", "sample.go")
+	writeTestFile(t, goPath, unformatted)
+	writeTestFile(t, filepath.Join(stage, "proto", "api.proto"), "syntax = \"proto3\";")
+
+	if err := formatStagedGo(stage); err != nil {
+		t.Fatal(err)
+	}
+
+	formatted, err := os.ReadFile(goPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(formatted) == unformatted {
+		t.Fatal("formatStagedGo left a non-goimports-clean file unchanged")
+	}
+	// The lint's own check must now find nothing to fix.
+	fixed, err := imports.Process(goPath, formatted, &imports.Options{Comments: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(fixed) != string(formatted) {
+		t.Fatalf("lint still reports drift after formatting:\n%s", fixed)
+	}
+	// Idempotent: a second sync produces no further change, so sync-drift passes.
+	if err := formatStagedGo(stage); err != nil {
+		t.Fatal(err)
+	}
+	assertTestFile(t, goPath, string(formatted))
+	// Non-Go staged input is left untouched.
+	assertTestFile(t, filepath.Join(stage, "proto", "api.proto"), "syntax = \"proto3\";")
+}
 
 func TestSyncTransactionDryRunPredictsAndAppliesExactTree(t *testing.T) {
 	root := t.TempDir()

--- a/sync_transaction_test.go
+++ b/sync_transaction_test.go
@@ -48,6 +48,42 @@ func TestFormatStagedGoMatchesLint(t *testing.T) {
 	assertTestFile(t, filepath.Join(stage, "proto", "api.proto"), "syntax = \"proto3\";")
 }
 
+// TestFormatStagedGoSkipsUnparseableFile verifies that a .go file goimports
+// cannot parse does not abort the sync and is left untouched.
+func TestFormatStagedGoSkipsUnparseableFile(t *testing.T) {
+	stage := t.TempDir()
+	broken := "package sample\n\nfunc oops( {\n"
+	brokenPath := filepath.Join(stage, "gen", "broken.go")
+	writeTestFile(t, brokenPath, broken)
+
+	if err := formatStagedGo(stage); err != nil {
+		t.Fatalf("unparseable staged file aborted formatting: %v", err)
+	}
+	assertTestFile(t, brokenPath, broken)
+}
+
+// TestFormatStagedGoLeavesSymlinkTargetUntouched verifies that a .go symlink is
+// not dereferenced, so formatting cannot truncate a file outside the tree.
+func TestFormatStagedGoLeavesSymlinkTargetUntouched(t *testing.T) {
+	stage := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "outside.go")
+	unformatted := "package sample\n\nimport \"fmt\"\n\nfunc Use()  {fmt.Println()}\n"
+	writeTestFile(t, outside, unformatted)
+
+	link := filepath.Join(stage, "gen", "link.go")
+	if err := os.MkdirAll(filepath.Dir(link), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, link); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := formatStagedGo(stage); err != nil {
+		t.Fatal(err)
+	}
+	assertTestFile(t, outside, unformatted)
+}
+
 func TestSyncTransactionDryRunPredictsAndAppliesExactTree(t *testing.T) {
 	root := t.TempDir()
 	writeTestFile(t, filepath.Join(root, "gen", "changed.go"), "before")


### PR DESCRIPTION
Closes #15.

## Summary
- `codefly sync service` never passed generated Go through the same `goimports` the lint uses, so freshly generated `.pb.go` could be flagged as "needs Fix (goimports/gofmt)" by the agent's own lint (`corecode.GoCodeServer` → `golang.org/x/tools/imports`) even though `sync-drift` saw no change. Sync and lint disagreed on formatting.
- Sync now formats the staged tree with the exact `imports.Process(path, content, &imports.Options{Comments: true})` call the lint runs, compiled from the same pinned `x/tools` version, so the output is byte-identical to what lint expects and generated code is lint-clean out of the box.
- The pass is idempotent (`imports.Process` leaves an already-clean file untouched), so re-running sync produces no further change and `sync-drift` stays green.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] New `TestFormatStagedGoMatchesLint`: rewrites a non-goimports-clean staged file, asserts the lint's own `imports.Process` then reports zero drift, that a second pass is a no-op, and that non-Go staged input is untouched.