### PR TITLE
Bump published version to 0.1.13 (#19)

### DIFF
--- a/agent.codefly.yaml
+++ b/agent.codefly.yaml
@@ -1,4 +1,4 @@
 publisher: codefly.dev
 kind: codefly:service
 name: go-grpc
-version: 0.1.12
+version: 0.1.13


### PR DESCRIPTION
Closes #19.

## Summary
- Bumps the published agent version in `agent.codefly.yaml` from `0.1.12` to `0.1.13` so `codefly agent versions codefly.dev/go-grpc` reports the release that carries the already-merged fixes: build against core v0.2.33 / proto 0.0.11 (#17/#18) and the goimports sync fix (#15/#16).
- The manifest version is the only in-repo change a release needs; the GitHub release + `linux_amd64` asset are produced by the GoReleaser workflow that runs on a pushed `v*` tag (`.github/workflows/releaser.yml`).

## Release step (post-merge)
Cutting the release is completed by tagging `main` after this merges — that push triggers the GoReleaser workflow:
```
git tag v0.1.13 <merged-commit>
git push origin v0.1.13
```

## Dependency / risk
Per the issue, this release is built against core v0.2.33, which pulls the `codeflydev/proto:0.0.11` companion at runtime. That image must be published on Docker Hub (codefly-dev/core#67) before or alongside this tag, or agents built against v0.1.13 will fail to pull the companion. Publishing Docker images is outside this repository and this PR — flagging it so the tag is not pushed until 0.0.11 is live.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [ ] After merge: push `v0.1.13` tag and confirm GoReleaser publishes the GitHub release with the `linux_amd64` asset