### PR TITLE
Gracefully stop generated HTTP servers (codefly-dev/mind#142)

### DIFF
--- a/agent.codefly.yaml
+++ b/agent.codefly.yaml
@@ -1,4 +1,4 @@
 publisher: codefly.dev
 kind: codefly:service
 name: go-grpc
-version: 0.1.13
+version: 0.1.14

--- a/base/code/pkg/adapters/connect_gen.go
+++ b/base/code/pkg/adapters/connect_gen.go
@@ -23,10 +23,14 @@ import (
 // It handles all three protocols on a single port.
 type ConnectServer struct {
 	config *Configuration
+	server *http.Server
 }
 
 func NewConnectServer(c *Configuration) (*ConnectServer, error) {
-	return &ConnectServer{config: c}, nil
+	return &ConnectServer{
+		config: c,
+		server: &http.Server{Addr: fmt.Sprintf(":%d", *c.EndpointConnectPort)},
+	}, nil
 }
 
 // connectHandler wraps the GrpcServer to implement the Connect handler interface.
@@ -57,10 +61,13 @@ func (s *ConnectServer) Run(ctx context.Context) error {
 	mux.Handle(path, handler)
 
 	// Use h2c for HTTP/2 without TLS (development mode)
-	server := &http.Server{
-		Addr:    fmt.Sprintf(":%d", port),
-		Handler: h2c.NewHandler(mux, &http2.Server{}),
+	s.server.Handler = h2c.NewHandler(mux, &http2.Server{})
+	if err := s.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		return err
 	}
+	return nil
+}
 
-	return server.ListenAndServe()
+func (s *ConnectServer) Shutdown(ctx context.Context) error {
+	return s.server.Shutdown(ctx)
 }

--- a/base/code/pkg/adapters/rest_gen.go
+++ b/base/code/pkg/adapters/rest_gen.go
@@ -7,9 +7,9 @@ package adapters
 ----------------------------------------------------------------- */
 
 import (
+	"bytes"
 	"codefly-base/pkg/gen"
 	"codefly-base/plugins"
-	"bytes"
 	"context"
 	"fmt"
 	"google.golang.org/grpc/grpclog"
@@ -29,10 +29,14 @@ import (
 
 type RestServer struct {
 	config *Configuration
+	server *http.Server
 }
 
 func NewRestServer(c *Configuration) (*RestServer, error) {
-	server := &RestServer{config: c}
+	server := &RestServer{
+		config: c,
+		server: &http.Server{Addr: fmt.Sprintf(":%d", *c.EndpointHttpPort)},
+	}
 	// Start Rest server (and proxy calls to gRPC server endpoint)
 	return server, nil
 }
@@ -100,7 +104,15 @@ func (s *RestServer) Run(ctx context.Context) error {
 	// Wrap your mux with the CORS handler
 	handler := c.Handler(gwMux)
 
-	return http.ListenAndServe(fmt.Sprintf(":%d", *s.config.EndpointHttpPort), logRequestBody(handler))
+	s.server.Handler = logRequestBody(handler)
+	if err := s.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		return err
+	}
+	return nil
+}
+
+func (s *RestServer) Shutdown(ctx context.Context) error {
+	return s.server.Shutdown(ctx)
 }
 
 type logResponseWriter struct {

--- a/base/code/pkg/adapters/server_gen.go
+++ b/base/code/pkg/adapters/server_gen.go
@@ -11,6 +11,7 @@ import (
 	"codefly-base/plugins"
 	"context"
 	"fmt"
+	"time"
 )
 
 type Server struct {
@@ -76,6 +77,20 @@ func (server *Server) Start(ctx context.Context) error {
 
 func (server *Server) Stop() {
 	fmt.Println("Stopping server...")
+	if server.rest != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		if err := server.rest.Shutdown(ctx); err != nil {
+			fmt.Printf("failed to stop REST server: %v\n", err)
+		}
+		cancel()
+	}
+	if server.connect != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		if err := server.connect.Shutdown(ctx); err != nil {
+			fmt.Printf("failed to stop Connect server: %v\n", err)
+		}
+		cancel()
+	}
 	server.grpc.health.Shutdown()
 	server.grpc.gRPC.GracefulStop()
 }

--- a/base/code/pkg/adapters/server_gen_test.go
+++ b/base/code/pkg/adapters/server_gen_test.go
@@ -1,0 +1,83 @@
+package adapters
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestServerStopReleasesHTTPListeners(t *testing.T) {
+	ports := unusedPorts(t, 3)
+	config := &Configuration{
+		EndpointGrpcPort:    ports[0],
+		EndpointHttpPort:    portPointer(ports[1]),
+		EndpointConnectPort: portPointer(ports[2]),
+	}
+
+	for run := 0; run < 2; run++ {
+		server, err := NewServer(config)
+		if err != nil {
+			t.Fatalf("create server for run %d: %v", run, err)
+		}
+
+		started := make(chan error, 1)
+		go func() {
+			started <- server.Start(context.Background())
+		}()
+
+		waitForHTTP(t, fmt.Sprintf("http://127.0.0.1:%d/healthz", *config.EndpointHttpPort))
+		waitForHTTP(t, fmt.Sprintf("http://127.0.0.1:%d/", *config.EndpointConnectPort))
+		server.Stop()
+
+		select {
+		case err := <-started:
+			if err != nil {
+				t.Fatalf("stop server for run %d: %v", run, err)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatalf("server run %d did not stop", run)
+		}
+	}
+}
+
+func unusedPorts(t *testing.T, count int) []uint16 {
+	t.Helper()
+	listeners := make([]net.Listener, 0, count)
+	for range count {
+		listener, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("allocate port: %v", err)
+		}
+		listeners = append(listeners, listener)
+	}
+	ports := make([]uint16, 0, count)
+	for _, listener := range listeners {
+		ports = append(ports, uint16(listener.Addr().(*net.TCPAddr).Port))
+		if err := listener.Close(); err != nil {
+			t.Fatalf("release port: %v", err)
+		}
+	}
+	return ports
+}
+
+func portPointer(port uint16) *uint16 {
+	return &port
+}
+
+func waitForHTTP(t *testing.T, url string) {
+	t.Helper()
+	client := &http.Client{Timeout: 250 * time.Millisecond}
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		response, err := client.Get(url)
+		if err == nil {
+			response.Body.Close()
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("HTTP server did not start at %s", url)
+}

--- a/proto_template_test.go
+++ b/proto_template_test.go
@@ -109,6 +109,8 @@ func TestGeneratedServiceOmitsRESTImplementationWhenDisabled(t *testing.T) {
 		"rest    *RestServer",
 		"rest:    rest",
 		"if server.rest != nil",
+		"server.rest.Shutdown(ctx)",
+		"server.connect.Shutdown(ctx)",
 	} {
 		if !strings.Contains(string(serverTemplate), want) {
 			t.Errorf("server adapter does not condition REST plumbing on settings: missing %q", want)
@@ -121,6 +123,20 @@ func TestGeneratedServiceOmitsRESTImplementationWhenDisabled(t *testing.T) {
 	}
 	if !strings.Contains(string(restTemplate), "{{- if .Settings.RestEndpoint }}") {
 		t.Error("REST adapter implementation is emitted for gRPC-only services")
+	}
+	for _, templatePath := range []string{
+		"templates/factory/code/pkg/adapters/rest_gen.go.tmpl",
+		"templates/factory/code/pkg/adapters/connect_gen.go.tmpl",
+	} {
+		httpTemplate, err := factoryFS.ReadFile(templatePath)
+		if err != nil {
+			t.Fatalf("read HTTP adapter template: %v", err)
+		}
+		for _, want := range []string{"server *http.Server", "s.server.Shutdown(ctx)"} {
+			if !strings.Contains(string(httpTemplate), want) {
+				t.Errorf("%s does not contain %q", templatePath, want)
+			}
+		}
 	}
 }
 

--- a/templates/factory/code/pkg/adapters/connect_gen.go.tmpl
+++ b/templates/factory/code/pkg/adapters/connect_gen.go.tmpl
@@ -23,10 +23,14 @@ import (
 // It handles all three protocols on a single port.
 type ConnectServer struct {
 	config *Configuration
+	server *http.Server
 }
 
 func NewConnectServer(c *Configuration) (*ConnectServer, error) {
-	return &ConnectServer{config: c}, nil
+	return &ConnectServer{
+		config: c,
+		server: &http.Server{Addr: fmt.Sprintf(":%d", *c.EndpointConnectPort)},
+	}, nil
 }
 
 // connectHandler wraps the GrpcServer to implement the Connect handler interface.
@@ -57,10 +61,13 @@ func (s *ConnectServer) Run(ctx context.Context) error {
 	mux.Handle(path, handler)
 
 	// Use h2c for HTTP/2 without TLS (development mode)
-	server := &http.Server{
-		Addr:    fmt.Sprintf(":%d", port),
-		Handler: h2c.NewHandler(mux, &http2.Server{}),
+	s.server.Handler = h2c.NewHandler(mux, &http2.Server{})
+	if err := s.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		return err
 	}
+	return nil
+}
 
-	return server.ListenAndServe()
+func (s *ConnectServer) Shutdown(ctx context.Context) error {
+	return s.server.Shutdown(ctx)
 }

--- a/templates/factory/code/pkg/adapters/rest_gen.go.tmpl
+++ b/templates/factory/code/pkg/adapters/rest_gen.go.tmpl
@@ -31,10 +31,14 @@ import (
 
 type RestServer struct {
 	config *Configuration
+	server *http.Server
 }
 
 func NewRestServer(c *Configuration) (*RestServer, error) {
-	server := &RestServer{config: c}
+	server := &RestServer{
+		config: c,
+		server: &http.Server{Addr: fmt.Sprintf(":%d", *c.EndpointHttpPort)},
+	}
 	// Start Rest server (and proxy calls to gRPC server endpoint)
 	return server, nil
 }
@@ -102,7 +106,15 @@ func (s *RestServer) Run(ctx context.Context) error {
 	// Wrap your mux with the CORS handler
 	handler := c.Handler(gwMux)
 
-	return http.ListenAndServe(fmt.Sprintf(":%d", *s.config.EndpointHttpPort), logRequestBody(handler))
+	s.server.Handler = logRequestBody(handler)
+	if err := s.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		return err
+	}
+	return nil
+}
+
+func (s *RestServer) Shutdown(ctx context.Context) error {
+	return s.server.Shutdown(ctx)
 }
 
 type logResponseWriter struct {

--- a/templates/factory/code/pkg/adapters/server_gen.go.tmpl
+++ b/templates/factory/code/pkg/adapters/server_gen.go.tmpl
@@ -11,6 +11,7 @@ import (
 	"{{ .Service.Name.DNSCase }}/plugins"
 	"context"
 	"fmt"
+	"time"
 )
 
 type Server struct {
@@ -84,6 +85,22 @@ func (server *Server) Start(ctx context.Context) error {
 
 func (server *Server) Stop() {
 	fmt.Println("Stopping server...")
+	{{- if .Settings.RestEndpoint }}
+	if server.rest != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		if err := server.rest.Shutdown(ctx); err != nil {
+			fmt.Printf("failed to stop REST server: %v\n", err)
+		}
+		cancel()
+	}
+	{{- end }}
+	if server.connect != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		if err := server.connect.Shutdown(ctx); err != nil {
+			fmt.Printf("failed to stop Connect server: %v\n", err)
+		}
+		cancel()
+	}
 	server.grpc.health.Shutdown()
 	server.grpc.gRPC.GracefulStop()
 }


### PR DESCRIPTION
Supports codefly-dev/mind#142.

## Summary

- Retain the generated REST and Connect `http.Server` instances so service shutdown releases every listener before a restart.
- Treat graceful HTTP closure as success and cover same-process restart on the exact same gRPC, REST, and Connect ports.
- Publish the fix as the next agent version so Mind can regenerate its adapters and restore the coordinator gate.

## Test plan

- [x] `go test ./...`
- [x] Race-enabled `TestServerStopReleasesHTTPListeners` against real gRPC, REST, and Connect listeners
- [ ] `codefly agent ci` locally (the validator reached packaging, then its isolated source stage could not download the currently unpublished `codefly.dev/go:0.0.16` packager)
