### PR TITLE
Skip Buf private .cache during staged Go formatting (#24)

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -240,6 +240,14 @@ func formatStagedGo(root string) error {
 		if walkErr != nil {
 			return walkErr
 		}
+		// Buf leaves a private .cache directory in the staging root. A
+		// containerized generator can create it as a foreign UID, leaving it
+		// unreadable; descending into it would abort a non-mutating sync with a
+		// permission error. It never holds generator-owned .go output, so skip
+		// it before WalkDir tries to read its entries.
+		if entry.IsDir() && entry.Name() == syncCacheDir {
+			return filepath.SkipDir
+		}
 		// Only regular .go files: a symlink ending in .go would be dereferenced
 		// by the os.WriteFile below and truncate its target, possibly outside the
 		// staged tree.

--- a/sync_transaction.go
+++ b/sync_transaction.go
@@ -123,6 +123,9 @@ func (transaction *syncTransaction) ChangedFiles() ([]string, error) {
 const (
 	syncIncomingSuffix = ".codefly-sync-incoming"
 	syncBackupSuffix   = ".codefly-sync-backup"
+	// syncCacheDir is the private cache directory Buf writes into the staging
+	// root; it is never a sync target and must be excluded from tree traversal.
+	syncCacheDir = ".cache"
 )
 
 // pendingSwap tracks one changed target through the two-phase apply.

--- a/sync_transaction_test.go
+++ b/sync_transaction_test.go
@@ -84,6 +84,25 @@ func TestFormatStagedGoLeavesSymlinkTargetUntouched(t *testing.T) {
 	assertTestFile(t, outside, unformatted)
 }
 
+// TestFormatStagedGoSkipsUnreadableCache proves a non-mutating sync survives
+// the private .cache directory Buf leaves in the staging root even when a
+// containerized generator wrote it as a foreign UID, leaving it unreadable.
+func TestFormatStagedGoSkipsUnreadableCache(t *testing.T) {
+	stage := t.TempDir()
+	writeTestFile(t, filepath.Join(stage, "gen", "sample.go"), "package sample\n")
+	cache := filepath.Join(stage, syncCacheDir, "buf")
+	writeTestFile(t, filepath.Join(cache, "module.bin"), "cached")
+	if err := os.Chmod(filepath.Join(stage, syncCacheDir), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	// Restore permissions so t.TempDir cleanup can remove the tree.
+	t.Cleanup(func() { _ = os.Chmod(filepath.Join(stage, syncCacheDir), 0o755) })
+
+	if err := formatStagedGo(stage); err != nil {
+		t.Fatalf("unreadable staged .cache aborted formatting: %v", err)
+	}
+}
+
 func TestSyncTransactionDryRunPredictsAndAppliesExactTree(t *testing.T) {
 	root := t.TempDir()
 	writeTestFile(t, filepath.Join(root, "gen", "changed.go"), "before")


### PR DESCRIPTION
Closes #24.

## Summary

- Non-mutating sync drift aborted with `open .../.cache: permission denied` when a containerized proto generator wrote Buf's private `.cache` directory into the staging root as a foreign UID, leaving it unreadable by the host runner.
- `formatStagedGo` walks the entire staging tree; it descended into that root-owned `.cache` and surfaced the permission error as a sync failure. The `.cache` directory is Buf-private and never a sync target, so the walk now skips it before `WalkDir` tries to read its entries — mirroring how core's own dependency walk already treats `.cache`.

## Test plan

- [x] `go test ./...` passes.
- [x] New `TestFormatStagedGoSkipsUnreadableCache` reproduces the exact `open .../.cache: permission denied` failure with the fix reverted and passes with it.
- [x] `go vet ./...` and `gofmt` clean.