### PR TITLE
Tolerate an unreadable staged .cache during sync cleanup (#26)

### DIFF
--- a/sync_transaction.go
+++ b/sync_transaction.go
@@ -57,7 +57,17 @@ func (transaction *syncTransaction) Close() error {
 	if transaction == nil || transaction.stageRoot == "" {
 		return nil
 	}
-	return os.RemoveAll(transaction.stageRoot)
+	// os.RemoveAll tears down the whole staging tree except a directory it cannot
+	// list: Buf's private .cache, which a containerized generator running as a
+	// foreign UID can leave unreadable to this process. Such a .cache cannot be
+	// removed without running the generator as the host UID (an upstream fix), so
+	// the residual is an otherwise-empty temp dir the OS reaps — tolerate the
+	// permission error here rather than surfacing an unactionable cleanup failure.
+	err := os.RemoveAll(transaction.stageRoot)
+	if errors.Is(err, fs.ErrPermission) {
+		return nil
+	}
+	return err
 }
 
 func (transaction *syncTransaction) CopyInput(relative string) error {

--- a/sync_transaction_test.go
+++ b/sync_transaction_test.go
@@ -103,6 +103,38 @@ func TestFormatStagedGoSkipsUnreadableCache(t *testing.T) {
 	}
 }
 
+// TestSyncTransactionCloseToleratesUnreadableCache proves Close does not report
+// a cleanup failure when a containerized generator left an unreadable .cache in
+// the staging root. os.RemoveAll still deletes the rest of the tree and fails
+// only on the .cache it cannot list; Close swallows that permission error (the
+// .cache cannot be removed without the generator running as the host UID) and
+// returns nil.
+func TestSyncTransactionCloseToleratesUnreadableCache(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("unreadable directories do not block root")
+	}
+	transaction, err := newSyncTransaction(t.TempDir(), "modules/api")
+	if err != nil {
+		t.Fatal(err)
+	}
+	stage := transaction.StageRoot()
+	writeTestFile(t, filepath.Join(stage, "gen", "sample.go"), "package sample\n")
+	cacheDir := filepath.Join(stage, syncCacheDir)
+	writeTestFile(t, filepath.Join(cacheDir, "buf", "module.bin"), "cached")
+	if err := os.Chmod(cacheDir, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	// Restore permissions so the temp root can be reaped after the test.
+	t.Cleanup(func() { _ = os.Chmod(cacheDir, 0o755) })
+
+	if err := transaction.Close(); err != nil {
+		t.Fatalf("close aborted on unreadable staged .cache: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(stage, "gen")); !os.IsNotExist(err) {
+		t.Fatalf("staged tree not removed alongside unreadable .cache: %v", err)
+	}
+}
+
 func TestSyncTransactionDryRunPredictsAndAppliesExactTree(t *testing.T) {
 	root := t.TempDir()
 	writeTestFile(t, filepath.Join(root, "gen", "changed.go"), "before")


### PR DESCRIPTION
Refs #26.

## Summary

- `syncTransaction.Close` removed the staging root with a bare `os.RemoveAll`, which surfaces `open .../.cache: permission denied` when a containerized proto generator running as a foreign UID leaves its private `.cache` unreadable. `os.RemoveAll` still deletes the rest of the staging tree and fails only on that `.cache` — a directory this process can neither read nor remove.
- `Close` now swallows that permission error (via `errors.Is(err, fs.ErrPermission)`) so cleanup does not report an unactionable failure; any other error still surfaces.

## Scope / honesty

This PR only **normalizes cleanup**. It does **not**, on its own:

- **Fix the sync abort in #26.** `Close`'s return value is already discarded by its only caller (`builder.go` `defer func() { _ = transaction.Close() }()`), so this never aborted sync. The abort the issue reports originates in the `codefly-dev/core` proto companion / dependency-cache path, not here.
- **Stop the temp-dir leak.** A `.cache` owned by a foreign UID cannot be removed (or `chmod`'d) by this process at all; `os.RemoveAll` already deletes every sibling, so only `.cache` + an otherwise-empty temp dir remain, before and after this change. The OS reaps the temp dir.

Both of those require the proto companion to run as `hostUserSpec()` so `.cache` is host-owned in the first place — that fix lives in `codefly-dev/core` and is out of this repo's scope. I've therefore switched the issue reference to `Refs #26` rather than `Closes #26`, since merging this alone does not resolve the reported failure.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (full suite)
- [x] `TestSyncTransactionCloseToleratesUnreadableCache`: an unreadable (`0o000`) staged `.cache` — `Close` returns nil and the rest of the staged tree is removed (skipped under root, where permissions don't block removal)
- [x] `go vet ./...`, `gofmt`