### PR TITLE
Release v0.1.15 with the .cache SkipDir guard (#26)

### DIFF
--- a/agent.codefly.yaml
+++ b/agent.codefly.yaml
@@ -1,4 +1,4 @@
 publisher: codefly.dev
 kind: codefly:service
 name: go-grpc
-version: 0.1.14
+version: 0.1.15


### PR DESCRIPTION
Closes #26.

## Summary

- The Linux-CI `builder sync failed: open .../.cache: permission denied` abort is fixed by the `syncCacheDir` `SkipDir` guard in `formatStagedGo` (landed in #24/#25, `b8f6dcf`). Per the maintainer's investigation on the issue, that guard is the complete fix for this path — there is no remaining code gap.
- The reason `module-saas-starter` still fails is version pinning: `v0.1.13` and `v0.1.14` both predate `b8f6dcf`, so any consumer on those tags runs the unguarded traversal. Cutting `v0.1.15` from current `main` ships the guard.
- This PR only bumps `agent.codefly.yaml` to `0.1.15`; `main` already carries both the guard (#24/#25) and the cleanup normalization (#26/#27).

## Release step

GoReleaser triggers on a `v*` tag push (`.github/workflows/releaser.yml`), not on this version bump. After merge, push the `v0.1.15` tag on the merge commit to publish, then re-pin `go-grpc` in `module-saas-starter`.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (passes; sync-transaction `.cache` `0o000` tolerance test included)