### PR TITLE
Insert cross-package imports missing from generated gateway code (#30)

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -255,9 +255,11 @@ func (s *Builder) Sync(ctx context.Context, request *builderv0.SyncRequest) (*bu
 //
 // Formatting at the stage path is a valid stand-in for the lint's later run at
 // the real path because imports.Process is path-independent for this input:
-// with no LocalPrefix and no missing/unused imports — always true of generated
-// protobuf — it reduces to gofmt plus a std/non-std import sort, neither of
-// which depends on the file's location.
+// with no LocalPrefix and no missing/unused imports it reduces to gofmt plus a
+// std/non-std import sort, neither of which depends on the file's location.
+// Generated protobuf can reference a cross-package type without importing it
+// (#30); addGeneratedCrossPackageImports runs first and inserts those imports,
+// so the no-missing-imports precondition holds by the time this pass runs.
 func formatStagedGo(root string) error {
 	return filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
@@ -306,12 +308,15 @@ func formatStagedGo(root string) error {
 // index each generated package by its declared name, then once more to add the
 // missing import to any file that names a package it never imported. goModPath
 // supplies the module path that turns a staged directory into an import path;
-// if it cannot be read (e.g. during service creation, before go.mod exists) the
-// repair is skipped, leaving the tree exactly as generated.
+// when go.mod does not exist yet (e.g. during service creation) the repair is
+// skipped, leaving the tree exactly as generated.
 func addGeneratedCrossPackageImports(stageRoot, goModPath, moduleRoot string, goOutputDirs []string) error {
 	modContent, err := os.ReadFile(goModPath)
-	if err != nil {
+	if os.IsNotExist(err) {
 		return nil
+	}
+	if err != nil {
+		return err
 	}
 	modulePath := modfile.ModulePath(modContent)
 	if modulePath == "" {
@@ -380,9 +385,10 @@ func generatedPackagePaths(stageRoot, stageModuleRoot, modulePath string, goOutp
 
 // insertMissingImports adds an import for every generated package the file
 // names through a selector but never imports. A selector prefix is treated as a
-// package only when it matches a generated package name absent from the file's
-// own import block; the following goimports pass drops the import again if a
-// local of the same name shadows it, so no scope analysis is needed here.
+// package only when it matches a generated package name that is neither the
+// file's own package nor already in its import block; the following goimports
+// pass drops the import again if a local of the same name shadows it, so no
+// scope analysis is needed here.
 func insertMissingImports(path string, byName map[string]string) error {
 	content, err := os.ReadFile(path)
 	if err != nil {
@@ -393,9 +399,9 @@ func insertMissingImports(path string, byName map[string]string) error {
 	if err != nil {
 		return nil
 	}
-	imported := map[string]struct{}{}
+	resolved := map[string]struct{}{file.Name.Name: {}}
 	for _, spec := range file.Imports {
-		imported[importSpecName(spec)] = struct{}{}
+		resolved[importSpecName(spec)] = struct{}{}
 	}
 	missing := map[string]string{}
 	goast.Inspect(file, func(node goast.Node) bool {
@@ -407,7 +413,7 @@ func insertMissingImports(path string, byName map[string]string) error {
 		if !ok {
 			return true
 		}
-		if _, ok := imported[ident.Name]; ok {
+		if _, ok := resolved[ident.Name]; ok {
 			return true
 		}
 		if importPath, ok := byName[ident.Name]; ok {

--- a/builder.go
+++ b/builder.go
@@ -4,10 +4,17 @@ import (
 	"bytes"
 	"context"
 	"embed"
+	goast "go/ast"
+	"go/format"
+	goparser "go/parser"
+	"go/token"
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 
+	"golang.org/x/mod/modfile"
+	"golang.org/x/tools/go/ast/astutil"
 	"golang.org/x/tools/imports"
 
 	"github.com/bufbuild/protocompile/ast"
@@ -196,6 +203,22 @@ func (s *Builder) Sync(ctx context.Context, request *builderv0.SyncRequest) (*bu
 		}
 	}
 
+	// protoc-gen-grpc-gateway emits `pkg.RequestType` for request types declared
+	// in another proto package but omits the import, so the generated .pb.gw.go
+	// does not compile. goimports below cannot repair it: its candidate scan keys
+	// on the import path's last segment (v1), which never matches the package's
+	// own name (jobsv1). Resolve those references against the freshly generated
+	// tree and insert the missing imports before the goimports pass sorts them.
+	moduleImports := make([]string, 0, len(s.GoGrpc.Settings.protocolOutputDirs()))
+	for _, relative := range s.GoGrpc.Settings.protocolOutputDirs() {
+		if relative == moduleRoot || pathContains(moduleRoot, relative) {
+			moduleImports = append(moduleImports, relative)
+		}
+	}
+	if err := addGeneratedCrossPackageImports(transaction.StageRoot(), filepath.Join(s.Location, moduleRoot, "go.mod"), moduleRoot, moduleImports); err != nil {
+		return s.Base.Builder.SyncError(err)
+	}
+
 	// buf and the language plugins emit Go that the agent's own lint
 	// (corecode.GoCodeServer, golang.org/x/tools/imports) can still flag as
 	// needing a safe fix, because the two paths pinned different goimports
@@ -274,6 +297,150 @@ func formatStagedGo(root string) error {
 		}
 		return os.WriteFile(path, fixed, info.Mode().Perm())
 	})
+}
+
+// addGeneratedCrossPackageImports inserts imports that a generated Go file
+// references but does not declare — the protoc-gen-grpc-gateway cross-package
+// request-type bug (#30). Every such reference resolves to a sibling package in
+// the same freshly generated tree, so goOutputDirs are scanned twice: once to
+// index each generated package by its declared name, then once more to add the
+// missing import to any file that names a package it never imported. goModPath
+// supplies the module path that turns a staged directory into an import path;
+// if it cannot be read (e.g. during service creation, before go.mod exists) the
+// repair is skipped, leaving the tree exactly as generated.
+func addGeneratedCrossPackageImports(stageRoot, goModPath, moduleRoot string, goOutputDirs []string) error {
+	modContent, err := os.ReadFile(goModPath)
+	if err != nil {
+		return nil
+	}
+	modulePath := modfile.ModulePath(modContent)
+	if modulePath == "" {
+		return nil
+	}
+	byName, err := generatedPackagePaths(stageRoot, filepath.Join(stageRoot, moduleRoot), modulePath, goOutputDirs)
+	if err != nil {
+		return err
+	}
+	for _, relative := range goOutputDirs {
+		err := filepath.WalkDir(filepath.Join(stageRoot, relative), func(path string, entry fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if !entry.Type().IsRegular() || filepath.Ext(path) != ".go" {
+				return nil
+			}
+			return insertMissingImports(path, byName)
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// generatedPackagePaths maps each generated package's declared name to its
+// import path. A name declared by two packages is dropped: a bare reference to
+// it cannot be resolved to a single import, so it is left for the lint to flag.
+func generatedPackagePaths(stageRoot, stageModuleRoot, modulePath string, goOutputDirs []string) (map[string]string, error) {
+	byName := map[string]string{}
+	ambiguous := map[string]struct{}{}
+	for _, relative := range goOutputDirs {
+		err := filepath.WalkDir(filepath.Join(stageRoot, relative), func(path string, entry fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if !entry.Type().IsRegular() || filepath.Ext(path) != ".go" {
+				return nil
+			}
+			file, err := goparser.ParseFile(token.NewFileSet(), path, nil, goparser.PackageClauseOnly)
+			if err != nil {
+				return nil
+			}
+			name := file.Name.Name
+			rel, err := filepath.Rel(stageModuleRoot, filepath.Dir(path))
+			if err != nil {
+				return err
+			}
+			importPath := modulePath + "/" + filepath.ToSlash(rel)
+			if existing, ok := byName[name]; ok && existing != importPath {
+				ambiguous[name] = struct{}{}
+			}
+			byName[name] = importPath
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	for name := range ambiguous {
+		delete(byName, name)
+	}
+	return byName, nil
+}
+
+// insertMissingImports adds an import for every generated package the file
+// names through a selector but never imports. A selector prefix is treated as a
+// package only when it matches a generated package name absent from the file's
+// own import block; the following goimports pass drops the import again if a
+// local of the same name shadows it, so no scope analysis is needed here.
+func insertMissingImports(path string, byName map[string]string) error {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	fset := token.NewFileSet()
+	file, err := goparser.ParseFile(fset, path, content, goparser.ParseComments)
+	if err != nil {
+		return nil
+	}
+	imported := map[string]struct{}{}
+	for _, spec := range file.Imports {
+		imported[importSpecName(spec)] = struct{}{}
+	}
+	missing := map[string]string{}
+	goast.Inspect(file, func(node goast.Node) bool {
+		selector, ok := node.(*goast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		ident, ok := selector.X.(*goast.Ident)
+		if !ok {
+			return true
+		}
+		if _, ok := imported[ident.Name]; ok {
+			return true
+		}
+		if importPath, ok := byName[ident.Name]; ok {
+			missing[ident.Name] = importPath
+		}
+		return true
+	})
+	if len(missing) == 0 {
+		return nil
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	for name, importPath := range missing {
+		astutil.AddNamedImport(fset, file, name, importPath)
+	}
+	var buffer bytes.Buffer
+	if err := format.Node(&buffer, fset, file); err != nil {
+		return err
+	}
+	if bytes.Equal(content, buffer.Bytes()) {
+		return nil
+	}
+	return os.WriteFile(path, buffer.Bytes(), info.Mode().Perm())
+}
+
+func importSpecName(spec *goast.ImportSpec) string {
+	if spec.Name != nil {
+		return spec.Name.Name
+	}
+	path := strings.Trim(spec.Path.Value, `"`)
+	return path[strings.LastIndex(path, "/")+1:]
 }
 
 // generatedScaffoldSelect traverses only the directories required to reach

--- a/cross_package_imports_test.go
+++ b/cross_package_imports_test.go
@@ -100,6 +100,82 @@ func TestAddGeneratedCrossPackageImportsSkipsWithoutGoMod(t *testing.T) {
 	assertTestFile(t, gateway, string(before))
 }
 
+// TestAddGeneratedCrossPackageImportsReportsUnreadableGoMod proves a go.mod
+// that exists but cannot be read is surfaced as an error rather than silently
+// disabling the repair — only a missing go.mod is a valid skip. A directory at
+// the go.mod path yields a non-IsNotExist read error on every platform.
+func TestAddGeneratedCrossPackageImportsReportsUnreadableGoMod(t *testing.T) {
+	stage, _ := stageGeneratedTree(t)
+	goModDir := filepath.Join(stage, "code", "go.mod")
+	if err := os.MkdirAll(goModDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := addGeneratedCrossPackageImports(stage, goModDir, "code", []string{"code/pkg/gen"}); err == nil {
+		t.Fatal("unreadable go.mod was silently skipped instead of reported")
+	}
+}
+
+// TestAddGeneratedCrossPackageImportsSkipsOwnPackageSelector proves a selector
+// that names the file's own package is not turned into a self-import, which
+// would not compile.
+func TestAddGeneratedCrossPackageImportsSkipsOwnPackageSelector(t *testing.T) {
+	stage := t.TempDir()
+	goMod := writeGoMod(t, stage, "acc")
+	// A file in package accountsv1 that qualifies a name with its own package.
+	own := filepath.Join(stage, "code", "pkg", "gen", "saas", "accounts", "v1", "self.go")
+	writeTestFile(t, own, "package accountsv1\n\nvar Value = accountsv1.Thing\n")
+	before, err := os.ReadFile(own)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := addGeneratedCrossPackageImports(stage, goMod, "code", []string{"code/pkg/gen"}); err != nil {
+		t.Fatal(err)
+	}
+	assertTestFile(t, own, string(before))
+}
+
+// TestAddGeneratedCrossPackageImportsAddsMultiplePackages proves a file missing
+// references to two different generated packages receives both imports and, run
+// through the goimports pass Sync applies next, lands byte-stable regardless of
+// the order the imports were inserted.
+func TestAddGeneratedCrossPackageImportsAddsMultiplePackages(t *testing.T) {
+	stage := t.TempDir()
+	goMod := writeGoMod(t, stage, "acc")
+	writeTestFile(t, filepath.Join(stage, "code", "pkg", "gen", "saas", "jobs", "v1", "jobs.pb.go"),
+		"package jobsv1\n\ntype GetJobRequest struct{}\n")
+	writeTestFile(t, filepath.Join(stage, "code", "pkg", "gen", "saas", "billing", "v1", "billing.pb.go"),
+		"package billingv1\n\ntype GetInvoiceRequest struct{}\n")
+	gateway := filepath.Join(stage, "code", "pkg", "gen", "saas", "accounts", "v1", "platform_admin.pb.gw.go")
+	writeTestFile(t, gateway,
+		"package accountsv1\n\nfunc handle() {\n\tvar job jobsv1.GetJobRequest\n\tvar inv billingv1.GetInvoiceRequest\n\t_, _ = job, inv\n}\n")
+
+	if err := addGeneratedCrossPackageImports(stage, goMod, "code", []string{"code/pkg/gen"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := formatStagedGo(stage); err != nil {
+		t.Fatal(err)
+	}
+	out, err := os.ReadFile(gateway)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{`jobsv1 "acc/pkg/gen/saas/jobs/v1"`, `billingv1 "acc/pkg/gen/saas/billing/v1"`} {
+		if !strings.Contains(string(out), want) {
+			t.Fatalf("missing import %s in:\n%s", want, out)
+		}
+	}
+	// A repeated pass converges on the same bytes: sync-drift stays clean.
+	if err := addGeneratedCrossPackageImports(stage, goMod, "code", []string{"code/pkg/gen"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := formatStagedGo(stage); err != nil {
+		t.Fatal(err)
+	}
+	assertTestFile(t, gateway, string(out))
+}
+
 // TestAddGeneratedCrossPackageImportsSkipsAmbiguousName proves a package name
 // declared by two generated directories is not resolved: the reference could
 // mean either import, so it is left for the lint to flag rather than guessed.

--- a/cross_package_imports_test.go
+++ b/cross_package_imports_test.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// stageGeneratedTree lays out the #30 repro: a service module "acc" whose
+// grpc-gateway output references request types from a sibling proto package
+// (jobsv1, declared in a directory whose tail segment is v1) without importing
+// it, while the companion .pb.go imports the same package under a different
+// alias. Returns the staged root and the path of the broken gateway file.
+func stageGeneratedTree(t *testing.T) (string, string) {
+	t.Helper()
+	stage := t.TempDir()
+	writeTestFile(t, filepath.Join(stage, "code", "pkg", "gen", "saas", "jobs", "v1", "jobs.pb.go"),
+		"package jobsv1\n\ntype GetJobRequest struct{}\ntype ListJobsRequest struct{}\n")
+	writeTestFile(t, filepath.Join(stage, "code", "pkg", "gen", "saas", "accounts", "v1", "platform_admin.pb.go"),
+		"package accountsv1\n\nimport v1 \"acc/pkg/gen/saas/jobs/v1\"\n\nvar _ = v1.GetJobRequest{}\n")
+	gateway := filepath.Join(stage, "code", "pkg", "gen", "saas", "accounts", "v1", "platform_admin.pb.gw.go")
+	writeTestFile(t, gateway,
+		"package accountsv1\n\nfunc handle() {\n\tvar protoReq jobsv1.GetJobRequest\n\tvar list jobsv1.ListJobsRequest\n\t_, _ = protoReq, list\n}\n")
+	return stage, gateway
+}
+
+func writeGoMod(t *testing.T, stage, modulePath string) string {
+	t.Helper()
+	goMod := filepath.Join(stage, "code", "go.mod")
+	writeTestFile(t, goMod, "module "+modulePath+"\n\ngo 1.26\n")
+	return goMod
+}
+
+// TestAddGeneratedCrossPackageImportsRepairsGatewayFile proves the missing
+// cross-package import is inserted so the generated code compiles, and that a
+// second pass — and the goimports pass that follows in Sync — leave it byte
+// stable, so sync-drift and compile agree.
+func TestAddGeneratedCrossPackageImportsRepairsGatewayFile(t *testing.T) {
+	stage, gateway := stageGeneratedTree(t)
+	goMod := writeGoMod(t, stage, "acc")
+
+	if err := addGeneratedCrossPackageImports(stage, goMod, "code", []string{"code/pkg/gen"}); err != nil {
+		t.Fatal(err)
+	}
+	repaired, err := os.ReadFile(gateway)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(repaired), `jobsv1 "acc/pkg/gen/saas/jobs/v1"`) {
+		t.Fatalf("cross-package import not added:\n%s", repaired)
+	}
+
+	// The goimports pass Sync runs next must find nothing more to change, and a
+	// second repair pass must be a no-op: both are what keep sync-drift clean.
+	if err := formatStagedGo(stage); err != nil {
+		t.Fatal(err)
+	}
+	formatted, err := os.ReadFile(gateway)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := addGeneratedCrossPackageImports(stage, goMod, "code", []string{"code/pkg/gen"}); err != nil {
+		t.Fatal(err)
+	}
+	assertTestFile(t, gateway, string(formatted))
+}
+
+// TestAddGeneratedCrossPackageImportsLeavesCorrectFilesUntouched proves the
+// pass never rewrites a file whose references are already imported.
+func TestAddGeneratedCrossPackageImportsLeavesCorrectFilesUntouched(t *testing.T) {
+	stage, _ := stageGeneratedTree(t)
+	goMod := writeGoMod(t, stage, "acc")
+	sibling := filepath.Join(stage, "code", "pkg", "gen", "saas", "accounts", "v1", "platform_admin.pb.go")
+	before, err := os.ReadFile(sibling)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := addGeneratedCrossPackageImports(stage, goMod, "code", []string{"code/pkg/gen"}); err != nil {
+		t.Fatal(err)
+	}
+	assertTestFile(t, sibling, string(before))
+}
+
+// TestAddGeneratedCrossPackageImportsSkipsWithoutGoMod proves the pass leaves
+// the tree exactly as generated when the module path cannot be resolved (e.g.
+// before go.mod exists during service creation), rather than failing the sync.
+func TestAddGeneratedCrossPackageImportsSkipsWithoutGoMod(t *testing.T) {
+	stage, gateway := stageGeneratedTree(t)
+	before, err := os.ReadFile(gateway)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	missing := filepath.Join(stage, "code", "go.mod")
+	if err := addGeneratedCrossPackageImports(stage, missing, "code", []string{"code/pkg/gen"}); err != nil {
+		t.Fatal(err)
+	}
+	assertTestFile(t, gateway, string(before))
+}
+
+// TestAddGeneratedCrossPackageImportsSkipsAmbiguousName proves a package name
+// declared by two generated directories is not resolved: the reference could
+// mean either import, so it is left for the lint to flag rather than guessed.
+func TestAddGeneratedCrossPackageImportsSkipsAmbiguousName(t *testing.T) {
+	stage, gateway := stageGeneratedTree(t)
+	goMod := writeGoMod(t, stage, "acc")
+	// A second directory also declaring package jobsv1 makes the name ambiguous.
+	writeTestFile(t, filepath.Join(stage, "code", "pkg", "gen", "saas", "jobs", "v2", "jobs.pb.go"),
+		"package jobsv1\n\ntype GetJobRequest struct{}\n")
+	before, err := os.ReadFile(gateway)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := addGeneratedCrossPackageImports(stage, goMod, "code", []string{"code/pkg/gen"}); err != nil {
+		t.Fatal(err)
+	}
+	assertTestFile(t, gateway, string(before))
+}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/codefly-dev/core v0.2.36
 	github.com/codefly-dev/service-go v0.0.17
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/mod v0.37.0
 	golang.org/x/tools v0.47.0
 	google.golang.org/grpc v1.80.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -106,7 +107,6 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.53.0 // indirect
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
-	golang.org/x/mod v0.37.0 // indirect
 	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect


### PR DESCRIPTION
Closes #30.

## Summary

- `protoc-gen-grpc-gateway` emits `pkg.RequestType` for request types declared in another proto package but never emits the import, so `*.pb.gw.go` fails to compile — while `sync-drift` passed on it because `formatStagedGo`'s goimports could not add the import. goimports keys its candidate scan on the import path's last segment (`v1`), which never matches the package's own name (`jobsv1`), so it has no way to resolve the reference; the two checks were mutually unsatisfiable from the consumer repo.
- Sync now resolves each such reference against the freshly generated tree — indexing every generated package by its declared name, then adding the missing named import to any file that names a package it never imported — before the existing goimports pass sorts them. Generated and committed both carry the import, so `sync-drift` and compile agree.
- The pass is deterministic and idempotent: it is a no-op once imports are present, skips ambiguous package names and files whose references are already imported, and is skipped entirely when `go.mod` is not yet readable (e.g. during service creation).

## Test plan

- [x] `go test ./...` (full suite green)
- [x] New `cross_package_imports_test.go`: reproduces the #30 layout (gateway file referencing `jobsv1` from a `.../jobs/v1` directory without importing it) and asserts the import is inserted, that the following goimports pass and a second repair pass leave the file byte-stable, that already-correct files are untouched, that a missing `go.mod` is a no-op, and that an ambiguous package name is left for the lint.
- [x] `go build ./...` and `go vet ./...` clean