### PR TITLE
Redirect cross-service buf.gen outputs into the sync stage (#31)

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -138,6 +138,9 @@ func (s *Builder) Sync(ctx context.Context, request *builderv0.SyncRequest) (*bu
 	if err := transaction.CopyInput(protoDir); err != nil {
 		return s.Base.Builder.SyncError(err)
 	}
+	if err := redirectEscapingBufOutputs(transaction.StageRoot(), protoDir); err != nil {
+		return s.Base.Builder.SyncError(err)
+	}
 
 	scaffoldTargets, err := generatedScaffoldTargets(s.Location, filepath.Join(s.Location, protoDir), s.Information.Service.Name.Title+"Service")
 	if err != nil {

--- a/sync_buf_output.go
+++ b/sync_buf_output.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// crossServiceDiscardDir is the throwaway, untracked directory inside the sync
+// stage that receives generator output aimed outside the staged service tree.
+const crossServiceDiscardDir = ".codefly-cross-service"
+
+// redirectEscapingBufOutputs rewrites `out` directories in the staged
+// buf.gen.yaml that resolve outside the staged service tree so they land in a
+// throwaway inside the stage.
+//
+// A service that owns a proto may cross-write a consumer's client — the SaaS
+// accounts service emits its TypeScript client into a sibling frontend via
+// `out: ../../frontend/code/src/gen`. Sync stages only this service, and the
+// companion mounts that stage near the container root, so such a path escapes
+// the mount to a container-absolute directory (`/frontend`) that the non-root
+// host user the companion runs as on Linux cannot create — buf then dies with
+// `mkdir /frontend: permission denied`. On macOS the companion runs as root and
+// silently writes the same output into the throwaway container filesystem, so
+// the failure is Linux-only and easy to miss.
+//
+// A cross-service output is never a sync target — cleanSyncRelative rejects
+// non-local paths, so ChangedFiles/Apply only ever consider paths inside the
+// service — meaning this output is discarded no matter where it lands.
+// Redirecting it into the stage keeps every tracked output byte-identical while
+// letting the containerized generation succeed for any container user.
+func redirectEscapingBufOutputs(stageRoot, protoDir string) error {
+	bufGen := filepath.Join(stageRoot, protoDir, "buf.gen.yaml")
+	content, err := os.ReadFile(bufGen)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read staged buf.gen.yaml: %w", err)
+	}
+
+	var doc yaml.Node
+	if err := yaml.Unmarshal(content, &doc); err != nil {
+		return fmt.Errorf("parse staged buf.gen.yaml: %w", err)
+	}
+
+	bufRoot := filepath.Join(stageRoot, protoDir)
+	redirected := 0
+	for _, out := range bufGenOutputNodes(&doc) {
+		resolved := filepath.Clean(filepath.Join(bufRoot, out.Value))
+		if pathWithin(stageRoot, resolved) {
+			continue
+		}
+		target := filepath.Join(stageRoot, crossServiceDiscardDir, fmt.Sprintf("%d", redirected))
+		relative, err := filepath.Rel(bufRoot, target)
+		if err != nil {
+			return fmt.Errorf("scope cross-service output %q: %w", out.Value, err)
+		}
+		out.Value = filepath.ToSlash(relative)
+		redirected++
+	}
+	if redirected == 0 {
+		return nil
+	}
+
+	rewritten, err := yaml.Marshal(&doc)
+	if err != nil {
+		return fmt.Errorf("rewrite staged buf.gen.yaml: %w", err)
+	}
+	if err := os.WriteFile(bufGen, rewritten, 0o644); err != nil {
+		return fmt.Errorf("write staged buf.gen.yaml: %w", err)
+	}
+	return nil
+}
+
+// bufGenOutputNodes returns the scalar value nodes of every plugin `out:` entry
+// in a buf.gen.yaml document, so a caller can inspect and rewrite them in place.
+func bufGenOutputNodes(doc *yaml.Node) []*yaml.Node {
+	if doc.Kind != yaml.DocumentNode || len(doc.Content) == 0 {
+		return nil
+	}
+	root := doc.Content[0]
+	if root.Kind != yaml.MappingNode {
+		return nil
+	}
+	var plugins *yaml.Node
+	for i := 0; i+1 < len(root.Content); i += 2 {
+		if root.Content[i].Value == "plugins" {
+			plugins = root.Content[i+1]
+			break
+		}
+	}
+	if plugins == nil || plugins.Kind != yaml.SequenceNode {
+		return nil
+	}
+	var outs []*yaml.Node
+	for _, plugin := range plugins.Content {
+		if plugin.Kind != yaml.MappingNode {
+			continue
+		}
+		for i := 0; i+1 < len(plugin.Content); i += 2 {
+			if plugin.Content[i].Value == "out" && plugin.Content[i+1].Kind == yaml.ScalarNode {
+				outs = append(outs, plugin.Content[i+1])
+			}
+		}
+	}
+	return outs
+}
+
+// pathWithin reports whether path is root itself or a descendant of it.
+func pathWithin(root, path string) bool {
+	relative, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	return relative == "." || (relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator)))
+}

--- a/sync_buf_output_test.go
+++ b/sync_buf_output_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// stageBufGen writes a buf.gen.yaml into stageRoot/proto and returns the stage root.
+func stageBufGen(t *testing.T, body string) string {
+	t.Helper()
+	stageRoot := t.TempDir()
+	protoDir := filepath.Join(stageRoot, "proto")
+	if err := os.MkdirAll(protoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(protoDir, "buf.gen.yaml"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return stageRoot
+}
+
+// pluginOuts reads back every plugin `out` value from the staged buf.gen.yaml.
+func pluginOuts(t *testing.T, stageRoot string) []string {
+	t.Helper()
+	content, err := os.ReadFile(filepath.Join(stageRoot, "proto", "buf.gen.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc yaml.Node
+	if err := yaml.Unmarshal(content, &doc); err != nil {
+		t.Fatal(err)
+	}
+	var outs []string
+	for _, node := range bufGenOutputNodes(&doc) {
+		outs = append(outs, node.Value)
+	}
+	return outs
+}
+
+const bufGenWithCrossService = `version: v2
+plugins:
+  - local: protoc-gen-go
+    out: ../code/pkg/gen
+    opt: paths=source_relative
+  - local: protoc-gen-openapiv2
+    out: ../.cache/openapi
+  - local: protoc-gen-es
+    out: ../../frontend/code/src/gen
+    opt:
+      - target=ts
+`
+
+func TestRedirectEscapingBufOutputs_RedirectsOnlyEscapingOutputs(t *testing.T) {
+	stageRoot := stageBufGen(t, bufGenWithCrossService)
+
+	if err := redirectEscapingBufOutputs(stageRoot, "proto"); err != nil {
+		t.Fatalf("redirect: %v", err)
+	}
+
+	outs := pluginOuts(t, stageRoot)
+	want := []string{
+		"../code/pkg/gen",                     // in-tree: unchanged
+		"../.cache/openapi",                   // in-tree (buf's private cache): unchanged
+		"../" + crossServiceDiscardDir + "/0", // escaping: redirected into the stage
+	}
+	if len(outs) != len(want) {
+		t.Fatalf("got %d outputs %v, want %d %v", len(outs), outs, len(want), want)
+	}
+	for i := range want {
+		if outs[i] != want[i] {
+			t.Errorf("output %d = %q, want %q", i, outs[i], want[i])
+		}
+	}
+
+	// Every redirected output must resolve back inside the stage so the
+	// containerized generator can write it under any container user.
+	redirected := filepath.Clean(filepath.Join(stageRoot, "proto", outs[2]))
+	if !pathWithin(stageRoot, redirected) {
+		t.Errorf("redirected output %q escapes stage %q", redirected, stageRoot)
+	}
+}
+
+func TestRedirectEscapingBufOutputs_NoEscapeLeavesFileUntouched(t *testing.T) {
+	body := "version: v2\nplugins:\n  - local: protoc-gen-go\n    out: ../code/pkg/gen\n"
+	stageRoot := stageBufGen(t, body)
+	original, _ := os.ReadFile(filepath.Join(stageRoot, "proto", "buf.gen.yaml"))
+
+	if err := redirectEscapingBufOutputs(stageRoot, "proto"); err != nil {
+		t.Fatalf("redirect: %v", err)
+	}
+
+	rewritten, _ := os.ReadFile(filepath.Join(stageRoot, "proto", "buf.gen.yaml"))
+	if string(original) != string(rewritten) {
+		t.Errorf("buf.gen.yaml with no escaping output was rewritten:\n%s", rewritten)
+	}
+}
+
+func TestRedirectEscapingBufOutputs_MissingFileIsNoError(t *testing.T) {
+	if err := redirectEscapingBufOutputs(t.TempDir(), "proto"); err != nil {
+		t.Fatalf("missing buf.gen.yaml should be tolerated, got: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #31.

## Summary

- `Builder.Sync` fails on non-root Linux CI for a service whose `buf.gen.yaml` cross-writes a consumer's client outside its own tree (accounts emits TypeScript into a sibling frontend via `out: ../../frontend/code/src/gen`). Sync stages only the owning service and the companion mounts that stage near the container root, so the path escapes to a container-absolute `/frontend` the non-root host user can't create → `mkdir /frontend: permission denied`. macOS ran the companion as root and wrote it into the throwaway container fs, so the break was Linux-only and previously masked behind the `.cache` failure fixed in v0.1.15.
- A cross-service output is **never a sync target** — `cleanSyncRelative` rejects non-local paths, so `ChangedFiles`/`Apply` only ever consider paths inside the service, and this output is discarded wherever it lands. So the fix redirects any staged `buf.gen.yaml` `out` that resolves outside the staged service tree into a throwaway inside the stage. Tracked outputs stay byte-identical; containerized generation now succeeds for any container user.
- Only the `Sync` (sync-drift) staging path is touched. The in-place `buf generate` command (`cmdProto`) that canonically regenerates the real cross-service files is unaffected.

## Test plan

- [x] `go test ./...` (full suite) + `go vet ./...` pass.
- [x] New unit tests (`sync_buf_output_test.go`): escaping `out` (`../../frontend/...`) is redirected into the stage while in-tree outs (`../code/pkg/gen`, `../.cache/openapi`) are untouched; a file with no escape is left byte-identical; a missing `buf.gen.yaml` is tolerated.
- [ ] End-to-end on Linux CI: verified downstream on `codefly-dev/module-saas-starter` PR #11 once this ships in a release and is re-pinned (the `mkdir /frontend` failure only reproduces under the non-root Linux companion; macOS runs the companion as root and cannot exercise it).

## Notes

Surfaced by module-saas-starter#10 / PR #11: v0.1.15 cleared the `.cache` blocker and fail-fast advanced to this next wall on `accounts` sync-drift.
