### PR TITLE
release: v0.1.17 (#34)

### DIFF
--- a/agent.codefly.yaml
+++ b/agent.codefly.yaml
@@ -1,4 +1,4 @@
 publisher: codefly.dev
 kind: codefly:service
 name: go-grpc
-version: 0.1.15
+version: 0.1.17


### PR DESCRIPTION
Closes #34.

## Summary

- The `v0.1.17` tag and its GitHub release assets (`linux_amd64`, `darwin_*`, checksums) are **already published**, cut from `5f976b2f` — the "Insert cross-package imports missing from generated gateway code" fix (#30 / PR #32). `releaser.yml` fires on the tag push, so the release did not need this PR to exist. This closes the tracking issue and realigns the manifest.
- The service manifest (`agent.codefly.yaml`) was left at `0.1.15` across the `v0.1.16` and `v0.1.17` tags; this bumps it to `0.1.17` so the checked-in version matches the latest published release.
- Consumer `module-saas-starter#7` was failing lint on `platform_admin.pb.gw.go: undefined: jobsv1` because `v0.1.16` predates the fix; it can now re-pin to `v0.1.17`.

## Test plan

- [x] `v0.1.17` tag resolves to `5f976b2f` (`git rev-parse v0.1.17`), which includes fix #32.
- [x] `gh release view v0.1.17` shows a published release with the `service-go-grpc_0.1.17_linux_amd64.tar.gz` asset.
- [x] `agent.codefly.yaml` now reads `version: 0.1.17`.