### PR TITLE
Harden generated Go service images

### DIFF
--- a/dockerfile_template_test.go
+++ b/dockerfile_template_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"io/fs"
+	"strings"
+	"testing"
+)
+
+func TestDockerfileTemplateUsesPinnedMinimalImages(t *testing.T) {
+	t.Parallel()
+
+	template, err := fs.ReadFile(builderFS, "templates/builder/Dockerfile.tmpl")
+	if err != nil {
+		t.Fatalf("read Dockerfile template: %v", err)
+	}
+	source := string(template)
+
+	if !strings.Contains(source, "FROM golang:{{ .GoVersion }}-alpine3.23@sha256:") {
+		t.Fatal("builder image must use the exact Go version and an immutable digest")
+	}
+	if !strings.Contains(source, "FROM alpine:{{ .AlpineVersion }}@sha256:") {
+		t.Fatal("runtime image must use the exact Alpine version and an immutable digest")
+	}
+
+	runtimeStart := strings.Index(source, "# Final stage")
+	if runtimeStart < 0 {
+		t.Fatal("runtime stage marker is missing")
+	}
+	runtimeStage := source[runtimeStart:]
+	if strings.Contains(runtimeStage, "ca-certificates git") {
+		t.Fatal("runtime image must not include git")
+	}
+	if !strings.Contains(runtimeStage, "RUN apk add --no-cache ca-certificates") {
+		t.Fatal("runtime image must retain the CA bundle")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -166,11 +166,11 @@ func NewService() *Service {
 	}
 }
 
-// GoVersion is the Go toolchain version used for container builds.
-const GoVersion = "1.26"
+// GoVersion is the exact Go patch release used for container builds.
+const GoVersion = "1.26.5"
 
-// AlpineVersion is the base Alpine version for container builds.
-const AlpineVersion = "3.21"
+// AlpineVersion is the exact runtime Alpine patch release used for container builds.
+const AlpineVersion = "3.23.5"
 
 // Runtime Image
 var runtimeImage = &configurations.DockerImage{Name: "codeflydev/go", Tag: "0.0.10"}

--- a/templates/builder/Dockerfile.tmpl
+++ b/templates/builder/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:{{ .GoVersion }}-alpine AS builder
+FROM golang:{{ .GoVersion }}-alpine3.23@sha256:622e56dbc11a8cfe87cafa2331e9a201877271cbff918af53d3be315f3da88cc AS builder
 
 ARG TARGETARCH
 
@@ -32,10 +32,10 @@ RUN if [ -f code/go.mod ]; then \
 {{- end }}
 
 # Final stage
-FROM alpine:{{ .AlpineVersion }}
+FROM alpine:{{ .AlpineVersion }}@sha256:fd791d74b68913cbb027c6546007b3f0d3bc45125f797758156952bc2d6daf40
 
-# Install ca-certificates for HTTPS and git for runtime operations
-RUN apk add --no-cache ca-certificates git
+# Runtime only needs the public CA bundle. Keep build tooling out of the image.
+RUN apk add --no-cache ca-certificates
 
 # Set working directory
 WORKDIR /app


### PR DESCRIPTION
## Summary
- pin generated Go builder and Alpine runtime images to exact patch releases and immutable digests
- remove Git from production runtime images
- lock the secure template contract with a regression test

## Validation
- `codefly agent build --dir ./service-go-grpc`