### PR TITLE
Upgrade generated services to Core v0.2.46

### DIFF
--- a/base/code/go.mod
+++ b/base/code/go.mod
@@ -7,7 +7,7 @@ toolchain go1.26.4
 require (
 	buf.build/go/protovalidate v1.2.0
 	connectrpc.com/connect v1.20.0
-	github.com/codefly-dev/core v0.2.45
+	github.com/codefly-dev/core v0.2.46
 	github.com/codefly-dev/sdk-go v0.1.65
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0
 	github.com/rs/cors v1.11.1

--- a/base/code/go.sum
+++ b/base/code/go.sum
@@ -14,8 +14,8 @@ github.com/brianvoe/gofakeit/v6 v6.28.0 h1:Xib46XXuQfmlLS2EXRuJpqcw8St6qSZz75OUo
 github.com/brianvoe/gofakeit/v6 v6.28.0/go.mod h1:Xj58BMSnFqcn/fAQeSK+/PLtC5kSb7FJIq4JyGa8vEs=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/codefly-dev/core v0.2.45 h1:9W6MzJ8Tc32mm16m/7SpA7kXFr38S6zz33OD23StJBw=
-github.com/codefly-dev/core v0.2.45/go.mod h1:Kke2ICKXwMOn4lhdiDLPxa68SciRnxcoc6igGqT1QgE=
+github.com/codefly-dev/core v0.2.46 h1:Kx6H+4WAXC1VlaAJ1V1zOZtdegXK0iqY37yiS9oniXY=
+github.com/codefly-dev/core v0.2.46/go.mod h1:Kke2ICKXwMOn4lhdiDLPxa68SciRnxcoc6igGqT1QgE=
 github.com/codefly-dev/sdk-go v0.1.65 h1:/AKs/XzaVW5P5VAPXSi8ZOUZHMP3N5bUq92DN6/Y2RM=
 github.com/codefly-dev/sdk-go v0.1.65/go.mod h1:IBVdaC5quw571pOELRCqZdhh6Y6pO5WE2F+jFG0EUEA=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.26.4
 
 require (
 	github.com/bufbuild/protocompile v0.14.1
-	github.com/codefly-dev/core v0.2.45
+	github.com/codefly-dev/core v0.2.46
 	github.com/codefly-dev/service-go v0.0.17
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/mod v0.37.0

--- a/go.sum
+++ b/go.sum
@@ -39,8 +39,8 @@ github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJ
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
-github.com/codefly-dev/core v0.2.45 h1:9W6MzJ8Tc32mm16m/7SpA7kXFr38S6zz33OD23StJBw=
-github.com/codefly-dev/core v0.2.45/go.mod h1:Kke2ICKXwMOn4lhdiDLPxa68SciRnxcoc6igGqT1QgE=
+github.com/codefly-dev/core v0.2.46 h1:Kx6H+4WAXC1VlaAJ1V1zOZtdegXK0iqY37yiS9oniXY=
+github.com/codefly-dev/core v0.2.46/go.mod h1:Kke2ICKXwMOn4lhdiDLPxa68SciRnxcoc6igGqT1QgE=
 github.com/codefly-dev/gortk v0.2.0 h1:7bOlS5valYz2zil+fZctQNcPCYBcPj86abcw9N8h1hQ=
 github.com/codefly-dev/gortk v0.2.0/go.mod h1:dDWUMFgAP063OCGhTEpV7FFUj9+zTcxxO/nV80VKEwg=
 github.com/codefly-dev/service-go v0.0.17 h1:ECdwUX0mRlDsSvXg3u5YGmhVYaa/o/U89wwdn0RjLtM=

--- a/templates/factory/code/go.mod.tmpl
+++ b/templates/factory/code/go.mod.tmpl
@@ -7,7 +7,7 @@ toolchain go1.26.4
 require (
 	buf.build/go/protovalidate v1.2.0
 	connectrpc.com/connect v1.20.0
-	github.com/codefly-dev/core v0.2.45
+	github.com/codefly-dev/core v0.2.46
 	github.com/codefly-dev/sdk-go v0.1.65
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0
 	github.com/rs/cors v1.11.1

--- a/templates/factory/code/go.sum.tmpl
+++ b/templates/factory/code/go.sum.tmpl
@@ -14,8 +14,8 @@ github.com/brianvoe/gofakeit/v6 v6.28.0 h1:Xib46XXuQfmlLS2EXRuJpqcw8St6qSZz75OUo
 github.com/brianvoe/gofakeit/v6 v6.28.0/go.mod h1:Xj58BMSnFqcn/fAQeSK+/PLtC5kSb7FJIq4JyGa8vEs=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/codefly-dev/core v0.2.45 h1:9W6MzJ8Tc32mm16m/7SpA7kXFr38S6zz33OD23StJBw=
-github.com/codefly-dev/core v0.2.45/go.mod h1:Kke2ICKXwMOn4lhdiDLPxa68SciRnxcoc6igGqT1QgE=
+github.com/codefly-dev/core v0.2.46 h1:Kx6H+4WAXC1VlaAJ1V1zOZtdegXK0iqY37yiS9oniXY=
+github.com/codefly-dev/core v0.2.46/go.mod h1:Kke2ICKXwMOn4lhdiDLPxa68SciRnxcoc6igGqT1QgE=
 github.com/codefly-dev/sdk-go v0.1.65 h1:/AKs/XzaVW5P5VAPXSi8ZOUZHMP3N5bUq92DN6/Y2RM=
 github.com/codefly-dev/sdk-go v0.1.65/go.mod h1:IBVdaC5quw571pOELRCqZdhh6Y6pO5WE2F+jFG0EUEA=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=


### PR DESCRIPTION
## Summary
- upgrade the agent runtime to Core v0.2.46
- keep the checked-in base service and factory template dependency locks identical
- propagate managed dependency reuse and isolated SDK test ports to generated Go services

## Validation
- `GOWORK=off go test ./...`
- `(cd base/code && GOWORK=off go test ./...)`
- `GOWORK=off go vet ./...`