### PR TITLE
Release Go gRPC v0.1.22

### DIFF
--- a/agent.codefly.yaml
+++ b/agent.codefly.yaml
@@ -1,4 +1,4 @@
 publisher: codefly.dev
 kind: codefly:service
 name: go-grpc
-version: 0.1.21
+version: 0.1.22


### PR DESCRIPTION
## Summary

- Publish the reviewed promotable GitOps generator through the official plugin version.

## Test plan

- [x] Feature PR CI
- [ ] Release PR CI
- [ ] Tagged release workflow
