### PR TITLE
Regenerate generated-service dependency lock (#45)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,5 +11,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  dependency-lock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Verify generated-service dependency lock
+        run: go test ./... -run '^Test(FactoryDependencyLocksMatchBase|BaseGeneratedServiceBuildsFromCleanModuleCache)$' -count=1
+
   ci:
+    needs: dependency-lock
     uses: codefly-dev/core/.github/workflows/go-service-ci.yml@main

--- a/agent.codefly.yaml
+++ b/agent.codefly.yaml
@@ -1,4 +1,4 @@
 publisher: codefly.dev
 kind: codefly:service
 name: go-grpc
-version: 0.1.22
+version: 0.1.23

--- a/base/code/go.mod
+++ b/base/code/go.mod
@@ -1,6 +1,6 @@
 module codefly-base
 
-go 1.25.0
+go 1.25.12
 
 toolchain go1.26.4
 
@@ -13,7 +13,7 @@ require (
 	github.com/rs/cors v1.11.1
 	golang.org/x/net v0.57.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20260420184626-e10c466a9529
-	google.golang.org/grpc v1.80.0
+	google.golang.org/grpc v1.82.1
 	google.golang.org/protobuf v1.36.11
 )
 
@@ -46,7 +46,6 @@ require (
 	github.com/oklog/ulid/v2 v2.1.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/yoheimuta/go-protoparser/v4 v4.14.2 // indirect
-	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
 	golang.org/x/sys v0.47.0 // indirect

--- a/base/code/go.sum
+++ b/base/code/go.sum
@@ -38,6 +38,7 @@ github.com/go-openapi/spec v0.22.4 h1:4pxGjipMKu0FzFiu/DPwN3CTBRlVM2yLf/YTWorYfD
 github.com/go-openapi/spec v0.22.4/go.mod h1:WQ6Ai0VPWMZgMT4XySjlRIE6GP1bGQOtEThn3gcWLtQ=
 github.com/go-openapi/strfmt v0.26.1 h1:7zGCHji7zSYDC2tCXIusoxYQz/48jAf2q+sF6wXTG+c=
 github.com/go-openapi/strfmt v0.26.1/go.mod h1:Zslk5VZPOISLwmWTMBIS7oiVFem1o1EI6zULY8Uer7Y=
+github.com/go-openapi/swag v0.23.0 h1:vsEVJDUo2hPJ2tu0/Xc+4noaxyEffXNIs3cOULZ+GrE=
 github.com/go-openapi/swag/conv v0.26.0 h1:5yGGsPYI1ZCva93U0AoKi/iZrNhaJEjr324YVsiD89I=
 github.com/go-openapi/swag/conv v0.26.0/go.mod h1:tpAmIL7X58VPnHHiSO4uE3jBeRamGsFsfdDeDtb5ECE=
 github.com/go-openapi/swag/jsonname v0.26.0 h1:gV1NFX9M8avo0YSpmWogqfQISigCmpaiNci8cGECU5w=
@@ -130,8 +131,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260420184626-e10c466a9529 h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260420184626-e10c466a9529/go.mod h1:a5OGAgyRr4lqco7AG9hQM9Fwh0N2ZV4grR0eXFEsXQg=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260420184626-e10c466a9529 h1:XF8+t6QQiS0o9ArVan/HW8Q7cycNPGsJf6GA2nXxYAg=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260420184626-e10c466a9529/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.80.0 h1:Xr6m2WmWZLETvUNvIUmeD5OAagMw3FiKmMlTdViWsHM=
-google.golang.org/grpc v1.80.0/go.mod h1:ho/dLnxwi3EDJA4Zghp7k2Ec1+c2jqup0bFkw07bwF4=
+google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
+google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/proto_template_test.go
+++ b/proto_template_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -97,6 +98,19 @@ func TestFactoryDependencyLocksMatchBase(t *testing.T) {
 	agentCore := dependencyLine(agentMod, "github.com/codefly-dev/core")
 	if generatedCore == "" || generatedCore != agentCore {
 		t.Fatalf("generated core dependency %q does not match agent dependency %q", generatedCore, agentCore)
+	}
+}
+
+func TestBaseGeneratedServiceBuildsFromCleanModuleCache(t *testing.T) {
+	command := exec.CommandContext(t.Context(), "go", "build", "-mod=readonly", "-modcacherw", "./...")
+	command.Dir = "base/code"
+	command.Env = append(os.Environ(),
+		"GOMODCACHE="+t.TempDir(),
+		"GOCACHE="+t.TempDir(),
+	)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("build generated service with clean caches: %v\n%s", err, output)
 	}
 }
 

--- a/proto_template_test.go
+++ b/proto_template_test.go
@@ -102,11 +102,14 @@ func TestFactoryDependencyLocksMatchBase(t *testing.T) {
 }
 
 func TestBaseGeneratedServiceBuildsFromCleanModuleCache(t *testing.T) {
+	t.Setenv("GOWORK", filepath.Join(t.TempDir(), "missing.go.work"))
+
 	command := exec.CommandContext(t.Context(), "go", "build", "-mod=readonly", "-modcacherw", "./...")
 	command.Dir = "base/code"
 	command.Env = append(os.Environ(),
 		"GOMODCACHE="+t.TempDir(),
 		"GOCACHE="+t.TempDir(),
+		"GOWORK=off",
 	)
 	output, err := command.CombinedOutput()
 	if err != nil {

--- a/templates/factory/code/go.mod.tmpl
+++ b/templates/factory/code/go.mod.tmpl
@@ -1,6 +1,6 @@
 module {{ .Service.Name.DNSCase }}
 
-go 1.25.0
+go 1.25.12
 
 toolchain go1.26.4
 
@@ -13,7 +13,7 @@ require (
 	github.com/rs/cors v1.11.1
 	golang.org/x/net v0.57.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20260420184626-e10c466a9529
-	google.golang.org/grpc v1.80.0
+	google.golang.org/grpc v1.82.1
 	google.golang.org/protobuf v1.36.11
 )
 
@@ -46,7 +46,6 @@ require (
 	github.com/oklog/ulid/v2 v2.1.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/yoheimuta/go-protoparser/v4 v4.14.2 // indirect
-	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
 	golang.org/x/sys v0.47.0 // indirect

--- a/templates/factory/code/go.sum.tmpl
+++ b/templates/factory/code/go.sum.tmpl
@@ -38,6 +38,7 @@ github.com/go-openapi/spec v0.22.4 h1:4pxGjipMKu0FzFiu/DPwN3CTBRlVM2yLf/YTWorYfD
 github.com/go-openapi/spec v0.22.4/go.mod h1:WQ6Ai0VPWMZgMT4XySjlRIE6GP1bGQOtEThn3gcWLtQ=
 github.com/go-openapi/strfmt v0.26.1 h1:7zGCHji7zSYDC2tCXIusoxYQz/48jAf2q+sF6wXTG+c=
 github.com/go-openapi/strfmt v0.26.1/go.mod h1:Zslk5VZPOISLwmWTMBIS7oiVFem1o1EI6zULY8Uer7Y=
+github.com/go-openapi/swag v0.23.0 h1:vsEVJDUo2hPJ2tu0/Xc+4noaxyEffXNIs3cOULZ+GrE=
 github.com/go-openapi/swag/conv v0.26.0 h1:5yGGsPYI1ZCva93U0AoKi/iZrNhaJEjr324YVsiD89I=
 github.com/go-openapi/swag/conv v0.26.0/go.mod h1:tpAmIL7X58VPnHHiSO4uE3jBeRamGsFsfdDeDtb5ECE=
 github.com/go-openapi/swag/jsonname v0.26.0 h1:gV1NFX9M8avo0YSpmWogqfQISigCmpaiNci8cGECU5w=
@@ -130,8 +131,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260420184626-e10c466a9529 h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260420184626-e10c466a9529/go.mod h1:a5OGAgyRr4lqco7AG9hQM9Fwh0N2ZV4grR0eXFEsXQg=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260420184626-e10c466a9529 h1:XF8+t6QQiS0o9ArVan/HW8Q7cycNPGsJf6GA2nXxYAg=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260420184626-e10c466a9529/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.80.0 h1:Xr6m2WmWZLETvUNvIUmeD5OAagMw3FiKmMlTdViWsHM=
-google.golang.org/grpc v1.80.0/go.mod h1:ho/dLnxwi3EDJA4Zghp7k2Ec1+c2jqup0bFkw07bwF4=
+google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
+google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
Closes #45.

## Summary

- Regenerate the generated-service module graph so Core v0.2.51 resolves its required Go and gRPC versions with complete checksums.
- Keep factory dependencies identical to the build-validated base lock and guard them with an isolated-cache build.
- Publish the correction as v0.1.23 while leaving v0.1.22 immutable.

## Test plan

- [x] go test ./... -run Test(FactoryDependencyLocksMatchBase|BaseGeneratedServiceBuildsFromCleanModuleCache) -count=1
- [x] go test ./... -count=1
- [x] go build ./...
- [x] go vet ./...
- [x] go mod tidy -diff
- [x] cd base/code && go mod tidy -diff