### PR TITLE
Build workspace-aware Go services (#49)

### DIFF
--- a/base/code/go.mod
+++ b/base/code/go.mod
@@ -7,7 +7,7 @@ toolchain go1.26.4
 require (
 	buf.build/go/protovalidate v1.2.0
 	connectrpc.com/connect v1.20.0
-	github.com/codefly-dev/core v0.2.52
+	github.com/codefly-dev/core v0.2.54
 	github.com/codefly-dev/sdk-go v0.1.65
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0
 	github.com/rs/cors v1.11.1

--- a/base/code/go.sum
+++ b/base/code/go.sum
@@ -14,8 +14,8 @@ github.com/brianvoe/gofakeit/v6 v6.28.0 h1:Xib46XXuQfmlLS2EXRuJpqcw8St6qSZz75OUo
 github.com/brianvoe/gofakeit/v6 v6.28.0/go.mod h1:Xj58BMSnFqcn/fAQeSK+/PLtC5kSb7FJIq4JyGa8vEs=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/codefly-dev/core v0.2.52 h1:bHudneVK/yLMxEc163v9Hm590E1Z6x7HWkZVdoA3CIA=
-github.com/codefly-dev/core v0.2.52/go.mod h1:hHJm+wOsHxpxKn4UMiFqBrGy0BE56iby9yptfygbdR4=
+github.com/codefly-dev/core v0.2.54 h1:evj8FEbJdarJ7jNd3OPo8a3xalXBwkdavoyvjUSyjrE=
+github.com/codefly-dev/core v0.2.54/go.mod h1:hHJm+wOsHxpxKn4UMiFqBrGy0BE56iby9yptfygbdR4=
 github.com/codefly-dev/sdk-go v0.1.65 h1:/AKs/XzaVW5P5VAPXSi8ZOUZHMP3N5bUq92DN6/Y2RM=
 github.com/codefly-dev/sdk-go v0.1.65/go.mod h1:IBVdaC5quw571pOELRCqZdhh6Y6pO5WE2F+jFG0EUEA=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=

--- a/builder.go
+++ b/builder.go
@@ -558,13 +558,43 @@ func (s *Builder) Build(ctx context.Context, req *builderv0.BuildRequest) (*buil
 	defer s.Wool.Catch()
 	ctx = s.Wool.Inject(ctx)
 
+	configure, err := goDockerTemplating(
+		s.GoGrpc.Settings,
+		s.Identity.WorkspacePath,
+		s.Location,
+	)
+	if err != nil {
+		return s.Base.Builder.BuildError(err)
+	}
 	return golanghelpers.BuildGoDocker(ctx, s.Base.Builder, req, s.Location,
-		requirements, builderFS, GoVersion, AlpineVersion,
-		func(d *golanghelpers.DockerTemplating) {
-			sourceDir := s.GoGrpc.Settings.GoSourceDir()
+		requirements, builderFS, GoVersion, AlpineVersion, configure)
+}
+
+func goDockerTemplating(
+	settings *Settings,
+	workspaceRoot,
+	serviceRoot string,
+) (func(*golanghelpers.DockerTemplating), error) {
+	sourceDir := settings.GoSourceDir()
+	moduleRoot, buildTarget := golanghelpers.SplitSourceDir(sourceDir)
+	if !settings.WithWorkspace {
+		return func(d *golanghelpers.DockerTemplating) {
 			d.SourceDir = sourceDir
-			d.ModuleRoot, d.BuildTarget = golanghelpers.SplitSourceDir(sourceDir)
-		})
+			d.ModuleRoot = moduleRoot
+			d.BuildTarget = buildTarget
+		}, nil
+	}
+	relativeService, err := filepath.Rel(workspaceRoot, serviceRoot)
+	if err != nil || relativeService == ".." || strings.HasPrefix(relativeService, ".."+string(filepath.Separator)) {
+		return nil, fmt.Errorf("service directory %q is outside workspace %q", serviceRoot, workspaceRoot)
+	}
+	return func(d *golanghelpers.DockerTemplating) {
+		d.SourceDir = filepath.ToSlash(filepath.Join(relativeService, sourceDir))
+		d.ModuleRoot = filepath.ToSlash(filepath.Join(relativeService, moduleRoot))
+		d.BuildTarget = buildTarget
+		d.ContextRoot = workspaceRoot
+		d.Workspace = true
+	}, nil
 }
 
 // Upgrade bumps Go module dependencies (go get -u=patch by default,

--- a/builder_workspace_test.go
+++ b/builder_workspace_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	golanghelpers "github.com/codefly-dev/core/runners/golang"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGoDockerTemplatingUsesWorkspaceForLocalModuleReplacements(t *testing.T) {
+	workspace := t.TempDir()
+	service := filepath.Join(workspace, "modules", "users", "services", "forge-edge")
+	settings := &Settings{}
+	settings.SourceDir = "code/cmd/server"
+	settings.WithWorkspace = true
+
+	configure, err := goDockerTemplating(settings, workspace, service)
+	require.NoError(t, err)
+	var docker golanghelpers.DockerTemplating
+	configure(&docker)
+
+	require.True(t, docker.Workspace)
+	require.Equal(t, workspace, docker.ContextRoot)
+	require.Equal(t, "modules/users/services/forge-edge/code", docker.ModuleRoot)
+	require.Equal(t, "./cmd/server", docker.BuildTarget)
+}
+
+func TestGoDockerTemplatingPreservesStandaloneServiceContext(t *testing.T) {
+	settings := &Settings{}
+	settings.SourceDir = "code/cmd/server"
+
+	configure, err := goDockerTemplating(settings, "/workspace", "/workspace/modules/users/services/accounts")
+	require.NoError(t, err)
+	var docker golanghelpers.DockerTemplating
+	configure(&docker)
+
+	require.False(t, docker.Workspace)
+	require.Empty(t, docker.ContextRoot)
+	require.Equal(t, "code", docker.ModuleRoot)
+	require.Equal(t, "./cmd/server", docker.BuildTarget)
+}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.26.4
 
 require (
 	github.com/bufbuild/protocompile v0.14.1
-	github.com/codefly-dev/core v0.2.52
+	github.com/codefly-dev/core v0.2.54
 	github.com/codefly-dev/service-go v0.0.17
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/mod v0.37.0

--- a/go.sum
+++ b/go.sum
@@ -41,8 +41,8 @@ github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJ
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
-github.com/codefly-dev/core v0.2.52 h1:bHudneVK/yLMxEc163v9Hm590E1Z6x7HWkZVdoA3CIA=
-github.com/codefly-dev/core v0.2.52/go.mod h1:hHJm+wOsHxpxKn4UMiFqBrGy0BE56iby9yptfygbdR4=
+github.com/codefly-dev/core v0.2.54 h1:evj8FEbJdarJ7jNd3OPo8a3xalXBwkdavoyvjUSyjrE=
+github.com/codefly-dev/core v0.2.54/go.mod h1:hHJm+wOsHxpxKn4UMiFqBrGy0BE56iby9yptfygbdR4=
 github.com/codefly-dev/gortk v0.2.0 h1:7bOlS5valYz2zil+fZctQNcPCYBcPj86abcw9N8h1hQ=
 github.com/codefly-dev/gortk v0.2.0/go.mod h1:dDWUMFgAP063OCGhTEpV7FFUj9+zTcxxO/nV80VKEwg=
 github.com/codefly-dev/service-go v0.0.17 h1:ECdwUX0mRlDsSvXg3u5YGmhVYaa/o/U89wwdn0RjLtM=

--- a/templates/builder/Dockerfile.tmpl
+++ b/templates/builder/Dockerfile.tmpl
@@ -9,6 +9,16 @@ RUN apk add --no-cache ca-certificates git
 # Set working directory
 WORKDIR /app
 
+{{- if .Workspace }}
+# Workspace-aware services may use local Go module replacements.
+ENV GOWORK=off
+COPY . .
+
+# Download dependencies and build from the service module.
+RUN cd {{ .ModuleRoot }} && go mod download
+RUN cd {{ .ModuleRoot }} && \
+    CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -ldflags='-w -s -extldflags "-static"' -o /app/app {{ .BuildTarget }}
+{{- else }}
 # Copy the source code
 {{ range .Components}}
 COPY {{.}} {{.}}
@@ -29,6 +39,7 @@ RUN if [ -f code/go.mod ]; then \
     else \
       echo "ERROR: no go.mod found" && exit 1; \
     fi
+{{- end }}
 {{- end }}
 
 # Final stage

--- a/templates/factory/code/go.mod.tmpl
+++ b/templates/factory/code/go.mod.tmpl
@@ -7,7 +7,7 @@ toolchain go1.26.4
 require (
 	buf.build/go/protovalidate v1.2.0
 	connectrpc.com/connect v1.20.0
-	github.com/codefly-dev/core v0.2.52
+	github.com/codefly-dev/core v0.2.54
 	github.com/codefly-dev/sdk-go v0.1.65
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0
 	github.com/rs/cors v1.11.1

--- a/templates/factory/code/go.sum.tmpl
+++ b/templates/factory/code/go.sum.tmpl
@@ -14,8 +14,8 @@ github.com/brianvoe/gofakeit/v6 v6.28.0 h1:Xib46XXuQfmlLS2EXRuJpqcw8St6qSZz75OUo
 github.com/brianvoe/gofakeit/v6 v6.28.0/go.mod h1:Xj58BMSnFqcn/fAQeSK+/PLtC5kSb7FJIq4JyGa8vEs=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/codefly-dev/core v0.2.52 h1:bHudneVK/yLMxEc163v9Hm590E1Z6x7HWkZVdoA3CIA=
-github.com/codefly-dev/core v0.2.52/go.mod h1:hHJm+wOsHxpxKn4UMiFqBrGy0BE56iby9yptfygbdR4=
+github.com/codefly-dev/core v0.2.54 h1:evj8FEbJdarJ7jNd3OPo8a3xalXBwkdavoyvjUSyjrE=
+github.com/codefly-dev/core v0.2.54/go.mod h1:hHJm+wOsHxpxKn4UMiFqBrGy0BE56iby9yptfygbdR4=
 github.com/codefly-dev/sdk-go v0.1.65 h1:/AKs/XzaVW5P5VAPXSi8ZOUZHMP3N5bUq92DN6/Y2RM=
 github.com/codefly-dev/sdk-go v0.1.65/go.mod h1:IBVdaC5quw571pOELRCqZdhh6Y6pO5WE2F+jFG0EUEA=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=


### PR DESCRIPTION
Closes #49.

## Summary

- Build services that declare workspace context from the exact Codefly workspace root so local module replacements remain available.
- Keep standalone services on the existing service-scoped Docker context.

## Test plan

- [x] `go test . -run TestGoDockerTemplating -count=1`
- [x] Built Mind accounts and forge-edge from their production workspace context
- [x] Rendered an immutable seven-service Mind local GitOps snapshot
- [ ] CI full suite (the local full suite reaches the real proto image and fails because `codeflydev/proto:0.0.12` has no arm64 manifest)