### PR TITLE
Release Go gRPC agent v0.1.24

### DIFF
--- a/agent.codefly.yaml
+++ b/agent.codefly.yaml
@@ -1,4 +1,4 @@
 publisher: codefly.dev
 kind: codefly:service
 name: go-grpc
-version: 0.1.23
+version: 0.1.24


### PR DESCRIPTION
## Summary

- Publish workspace-aware Docker builds and the synchronized generated-service dependency lock.

## Test plan

- [x] Upstream implementation CI passed in #50
- [ ] Release CI passes