### PR TITLE
Render selected environment fixtures in deployments (#52)

### DIFF
--- a/agent.codefly.yaml
+++ b/agent.codefly.yaml
@@ -1,4 +1,4 @@
 publisher: codefly.dev
 kind: codefly:service
 name: go-grpc
-version: 0.1.24
+version: 0.1.25

--- a/base/code/go.mod
+++ b/base/code/go.mod
@@ -7,7 +7,7 @@ toolchain go1.26.4
 require (
 	buf.build/go/protovalidate v1.2.0
 	connectrpc.com/connect v1.20.0
-	github.com/codefly-dev/core v0.2.54
+	github.com/codefly-dev/core v0.2.59
 	github.com/codefly-dev/sdk-go v0.1.65
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0
 	github.com/rs/cors v1.11.1

--- a/base/code/go.sum
+++ b/base/code/go.sum
@@ -14,8 +14,8 @@ github.com/brianvoe/gofakeit/v6 v6.28.0 h1:Xib46XXuQfmlLS2EXRuJpqcw8St6qSZz75OUo
 github.com/brianvoe/gofakeit/v6 v6.28.0/go.mod h1:Xj58BMSnFqcn/fAQeSK+/PLtC5kSb7FJIq4JyGa8vEs=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/codefly-dev/core v0.2.54 h1:evj8FEbJdarJ7jNd3OPo8a3xalXBwkdavoyvjUSyjrE=
-github.com/codefly-dev/core v0.2.54/go.mod h1:hHJm+wOsHxpxKn4UMiFqBrGy0BE56iby9yptfygbdR4=
+github.com/codefly-dev/core v0.2.59 h1:uEOoYFNRf6q7unRH37cDM7ccZuQ6QTDIHnuoDfGoDnA=
+github.com/codefly-dev/core v0.2.59/go.mod h1:hHJm+wOsHxpxKn4UMiFqBrGy0BE56iby9yptfygbdR4=
 github.com/codefly-dev/sdk-go v0.1.65 h1:/AKs/XzaVW5P5VAPXSi8ZOUZHMP3N5bUq92DN6/Y2RM=
 github.com/codefly-dev/sdk-go v0.1.65/go.mod h1:IBVdaC5quw571pOELRCqZdhh6Y6pO5WE2F+jFG0EUEA=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=

--- a/deployment_test.go
+++ b/deployment_test.go
@@ -9,3 +9,9 @@ import (
 func TestDeploymentTemplates(t *testing.T) {
 	agenttesting.AssertKustomizeTemplates(t, deploymentFS, nil)
 }
+
+func TestAgentVersion(t *testing.T) {
+	if agent.Version != "0.1.25" {
+		t.Fatalf("agent version = %q, want 0.1.25", agent.Version)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.26.4
 
 require (
 	github.com/bufbuild/protocompile v0.14.1
-	github.com/codefly-dev/core v0.2.54
+	github.com/codefly-dev/core v0.2.59
 	github.com/codefly-dev/service-go v0.0.17
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/mod v0.37.0

--- a/go.sum
+++ b/go.sum
@@ -41,8 +41,8 @@ github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJ
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
-github.com/codefly-dev/core v0.2.54 h1:evj8FEbJdarJ7jNd3OPo8a3xalXBwkdavoyvjUSyjrE=
-github.com/codefly-dev/core v0.2.54/go.mod h1:hHJm+wOsHxpxKn4UMiFqBrGy0BE56iby9yptfygbdR4=
+github.com/codefly-dev/core v0.2.59 h1:uEOoYFNRf6q7unRH37cDM7ccZuQ6QTDIHnuoDfGoDnA=
+github.com/codefly-dev/core v0.2.59/go.mod h1:hHJm+wOsHxpxKn4UMiFqBrGy0BE56iby9yptfygbdR4=
 github.com/codefly-dev/gortk v0.2.0 h1:7bOlS5valYz2zil+fZctQNcPCYBcPj86abcw9N8h1hQ=
 github.com/codefly-dev/gortk v0.2.0/go.mod h1:dDWUMFgAP063OCGhTEpV7FFUj9+zTcxxO/nV80VKEwg=
 github.com/codefly-dev/service-go v0.0.17 h1:ECdwUX0mRlDsSvXg3u5YGmhVYaa/o/U89wwdn0RjLtM=

--- a/templates/deployment/kustomize/base/deployment.yaml.tmpl
+++ b/templates/deployment/kustomize/base/deployment.yaml.tmpl
@@ -51,11 +51,11 @@ spec:
           envFrom:
             - configMapRef:
                 name: cm-{{ .Service.Name.DNSCase }}
-{{- if not .GitOps }}
+{{- if not .Restricted }}
             - secretRef:
                 name: secret-{{ .Service.Name.DNSCase }}
 {{- end }}
-{{- if .GitOps }}
+{{- if .Restricted }}
           env:
 {{- range $key, $reference := .SecretReferences }}
             - name: {{ $key }}

--- a/templates/deployment/kustomize/base/kustomization.yaml.tmpl
+++ b/templates/deployment/kustomize/base/kustomization.yaml.tmpl
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-{{- if not .GitOps }}
+{{- if not .Restricted }}
   - namespace.yaml
 {{- end }}
   - deployment.yaml

--- a/templates/deployment/kustomize/base/namespace.yaml.tmpl
+++ b/templates/deployment/kustomize/base/namespace.yaml.tmpl
@@ -1,4 +1,4 @@
-{{- if not .GitOps }}
+{{- if not .Restricted }}
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/templates/deployment/kustomize/overlays/environment/kustomization.yaml.tmpl
+++ b/templates/deployment/kustomize/overlays/environment/kustomization.yaml.tmpl
@@ -4,6 +4,6 @@ kind: Kustomization
 resources:
   - ../../base
   - configmap.yaml
-{{- if not .GitOps }}
+{{- if not .Restricted }}
   - secret.yaml
 {{- end }}

--- a/templates/deployment/kustomize/overlays/environment/secret.yaml.tmpl
+++ b/templates/deployment/kustomize/overlays/environment/secret.yaml.tmpl
@@ -1,4 +1,4 @@
-{{- if not .GitOps }}
+{{- if not .Restricted }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/templates/factory/code/go.mod.tmpl
+++ b/templates/factory/code/go.mod.tmpl
@@ -7,7 +7,7 @@ toolchain go1.26.4
 require (
 	buf.build/go/protovalidate v1.2.0
 	connectrpc.com/connect v1.20.0
-	github.com/codefly-dev/core v0.2.54
+	github.com/codefly-dev/core v0.2.59
 	github.com/codefly-dev/sdk-go v0.1.65
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0
 	github.com/rs/cors v1.11.1

--- a/templates/factory/code/go.sum.tmpl
+++ b/templates/factory/code/go.sum.tmpl
@@ -14,8 +14,8 @@ github.com/brianvoe/gofakeit/v6 v6.28.0 h1:Xib46XXuQfmlLS2EXRuJpqcw8St6qSZz75OUo
 github.com/brianvoe/gofakeit/v6 v6.28.0/go.mod h1:Xj58BMSnFqcn/fAQeSK+/PLtC5kSb7FJIq4JyGa8vEs=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/codefly-dev/core v0.2.54 h1:evj8FEbJdarJ7jNd3OPo8a3xalXBwkdavoyvjUSyjrE=
-github.com/codefly-dev/core v0.2.54/go.mod h1:hHJm+wOsHxpxKn4UMiFqBrGy0BE56iby9yptfygbdR4=
+github.com/codefly-dev/core v0.2.59 h1:uEOoYFNRf6q7unRH37cDM7ccZuQ6QTDIHnuoDfGoDnA=
+github.com/codefly-dev/core v0.2.59/go.mod h1:hHJm+wOsHxpxKn4UMiFqBrGy0BE56iby9yptfygbdR4=
 github.com/codefly-dev/sdk-go v0.1.65 h1:/AKs/XzaVW5P5VAPXSi8ZOUZHMP3N5bUq92DN6/Y2RM=
 github.com/codefly-dev/sdk-go v0.1.65/go.mod h1:IBVdaC5quw571pOELRCqZdhh6Y6pO5WE2F+jFG0EUEA=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=


### PR DESCRIPTION
Closes #52.\n\n## Summary\n\n- Render the selected workspace fixture through the released deployment-environment contract.\n- Keep restricted GitOps output free of inline Secrets while emitting external Secret references.\n\n## Test plan\n\n- [x] ok  	github.com/codefly-dev/service-go-grpc	(cached)\n- [x] Verify restricted and direct-deploy template branches against core v0.2.59.\n