### PR TITLE
Package selected module fixtures in workspace images (#54)

### DIFF
--- a/agent.codefly.yaml
+++ b/agent.codefly.yaml
@@ -1,4 +1,4 @@
 publisher: codefly.dev
 kind: codefly:service
 name: go-grpc
-version: 0.1.25
+version: 0.1.26

--- a/deployment_test.go
+++ b/deployment_test.go
@@ -11,7 +11,7 @@ func TestDeploymentTemplates(t *testing.T) {
 }
 
 func TestAgentVersion(t *testing.T) {
-	if agent.Version != "0.1.25" {
-		t.Fatalf("agent version = %q, want 0.1.25", agent.Version)
+	if agent.Version != "0.1.26" {
+		t.Fatalf("agent version = %q, want 0.1.26", agent.Version)
 	}
 }

--- a/dockerfile_template_test.go
+++ b/dockerfile_template_test.go
@@ -34,3 +34,23 @@ func TestDockerfileTemplateUsesPinnedMinimalImages(t *testing.T) {
 		t.Fatal("runtime image must retain the CA bundle")
 	}
 }
+
+func TestDockerfileTemplateCarriesModuleFixturesForWorkspaceBuilds(t *testing.T) {
+	t.Parallel()
+
+	template, err := fs.ReadFile(builderFS, "templates/builder/Dockerfile.tmpl")
+	if err != nil {
+		t.Fatalf("read Dockerfile template: %v", err)
+	}
+	source := string(template)
+
+	if !strings.Contains(source, `fixture_root="$(dirname "$(dirname "$(dirname "{{ .ModuleRoot }}")")")/fixtures"`) {
+		t.Fatal("workspace build must locate the containing module fixtures")
+	}
+	if !strings.Contains(source, "if [ -d \"$fixture_root\" ]; then cp -R \"$fixture_root\"/. /app/runtime-fixtures/; fi") {
+		t.Fatal("workspace build must stage only module fixture files when present")
+	}
+	if !strings.Contains(source, "COPY --chown=appuser --from=builder /app/runtime-fixtures ./fixtures") {
+		t.Fatal("workspace runtime must include the staged module fixtures")
+	}
+}

--- a/templates/builder/Dockerfile.tmpl
+++ b/templates/builder/Dockerfile.tmpl
@@ -18,6 +18,9 @@ COPY . .
 RUN cd {{ .ModuleRoot }} && go mod download
 RUN cd {{ .ModuleRoot }} && \
     CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -ldflags='-w -s -extldflags "-static"' -o /app/app {{ .BuildTarget }}
+RUN fixture_root="$(dirname "$(dirname "$(dirname "{{ .ModuleRoot }}")")")/fixtures"; \
+    mkdir -p /app/runtime-fixtures; \
+    if [ -d "$fixture_root" ]; then cp -R "$fixture_root"/. /app/runtime-fixtures/; fi
 {{- else }}
 # Copy the source code
 {{ range .Components}}
@@ -61,6 +64,9 @@ RUN adduser -D appuser
 
 # Copy the binary from the builder stage
 COPY --chown=appuser --from=builder /app/app .
+{{- if .Workspace }}
+COPY --chown=appuser --from=builder /app/runtime-fixtures ./fixtures
+{{- end }}
 
 # Use the non-root user
 USER appuser


### PR DESCRIPTION
Closes #54.

## Summary

- Carry the containing module fixture directory into workspace-aware runtime images so explicit environment fixture selection works after deployment.
- Keep standalone images and workspace services without fixtures unchanged by staging an empty fixture directory.

## Test plan

- [x] `GOWORK=off go test ./... -run '^Test(DockerfileTemplateCarriesModuleFixturesForWorkspaceBuilds|DockerfileTemplateUsesPinnedMinimalImages|DeploymentTemplates|AgentVersion|FactoryDependencyLocksMatchBase|BaseGeneratedServiceBuildsFromCleanModuleCache)$' -count=1`\n- [ ] Rebuild the agent and qualify the Mind accounts service in k3d.\n