### PR TITLE
Adopt transport-neutral manifest-bundle contract (#48)

### DIFF
--- a/base/code/go.mod
+++ b/base/code/go.mod
@@ -7,7 +7,7 @@ toolchain go1.26.4
 require (
 	buf.build/go/protovalidate v1.2.0
 	connectrpc.com/connect v1.20.0
-	github.com/codefly-dev/core v0.2.52
+	github.com/codefly-dev/core v0.2.59
 	github.com/codefly-dev/sdk-go v0.1.65
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0
 	github.com/rs/cors v1.11.1

--- a/base/code/go.sum
+++ b/base/code/go.sum
@@ -14,8 +14,8 @@ github.com/brianvoe/gofakeit/v6 v6.28.0 h1:Xib46XXuQfmlLS2EXRuJpqcw8St6qSZz75OUo
 github.com/brianvoe/gofakeit/v6 v6.28.0/go.mod h1:Xj58BMSnFqcn/fAQeSK+/PLtC5kSb7FJIq4JyGa8vEs=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/codefly-dev/core v0.2.52 h1:bHudneVK/yLMxEc163v9Hm590E1Z6x7HWkZVdoA3CIA=
-github.com/codefly-dev/core v0.2.52/go.mod h1:hHJm+wOsHxpxKn4UMiFqBrGy0BE56iby9yptfygbdR4=
+github.com/codefly-dev/core v0.2.59 h1:uEOoYFNRf6q7unRH37cDM7ccZuQ6QTDIHnuoDfGoDnA=
+github.com/codefly-dev/core v0.2.59/go.mod h1:hHJm+wOsHxpxKn4UMiFqBrGy0BE56iby9yptfygbdR4=
 github.com/codefly-dev/sdk-go v0.1.65 h1:/AKs/XzaVW5P5VAPXSi8ZOUZHMP3N5bUq92DN6/Y2RM=
 github.com/codefly-dev/sdk-go v0.1.65/go.mod h1:IBVdaC5quw571pOELRCqZdhh6Y6pO5WE2F+jFG0EUEA=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.26.4
 
 require (
 	github.com/bufbuild/protocompile v0.14.1
-	github.com/codefly-dev/core v0.2.52
+	github.com/codefly-dev/core v0.2.59
 	github.com/codefly-dev/service-go v0.0.17
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/mod v0.37.0

--- a/go.sum
+++ b/go.sum
@@ -41,8 +41,8 @@ github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJ
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
-github.com/codefly-dev/core v0.2.52 h1:bHudneVK/yLMxEc163v9Hm590E1Z6x7HWkZVdoA3CIA=
-github.com/codefly-dev/core v0.2.52/go.mod h1:hHJm+wOsHxpxKn4UMiFqBrGy0BE56iby9yptfygbdR4=
+github.com/codefly-dev/core v0.2.59 h1:uEOoYFNRf6q7unRH37cDM7ccZuQ6QTDIHnuoDfGoDnA=
+github.com/codefly-dev/core v0.2.59/go.mod h1:hHJm+wOsHxpxKn4UMiFqBrGy0BE56iby9yptfygbdR4=
 github.com/codefly-dev/gortk v0.2.0 h1:7bOlS5valYz2zil+fZctQNcPCYBcPj86abcw9N8h1hQ=
 github.com/codefly-dev/gortk v0.2.0/go.mod h1:dDWUMFgAP063OCGhTEpV7FFUj9+zTcxxO/nV80VKEwg=
 github.com/codefly-dev/service-go v0.0.17 h1:ECdwUX0mRlDsSvXg3u5YGmhVYaa/o/U89wwdn0RjLtM=

--- a/templates/deployment/kustomize/base/deployment.yaml.tmpl
+++ b/templates/deployment/kustomize/base/deployment.yaml.tmpl
@@ -51,11 +51,11 @@ spec:
           envFrom:
             - configMapRef:
                 name: cm-{{ .Service.Name.DNSCase }}
-{{- if not .GitOps }}
+{{- if not .Restricted }}
             - secretRef:
                 name: secret-{{ .Service.Name.DNSCase }}
 {{- end }}
-{{- if .GitOps }}
+{{- if .Restricted }}
           env:
 {{- range $key, $reference := .SecretReferences }}
             - name: {{ $key }}

--- a/templates/deployment/kustomize/base/kustomization.yaml.tmpl
+++ b/templates/deployment/kustomize/base/kustomization.yaml.tmpl
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-{{- if not .GitOps }}
+{{- if not .Restricted }}
   - namespace.yaml
 {{- end }}
   - deployment.yaml

--- a/templates/deployment/kustomize/base/namespace.yaml.tmpl
+++ b/templates/deployment/kustomize/base/namespace.yaml.tmpl
@@ -1,4 +1,4 @@
-{{- if not .GitOps }}
+{{- if not .Restricted }}
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/templates/deployment/kustomize/overlays/environment/kustomization.yaml.tmpl
+++ b/templates/deployment/kustomize/overlays/environment/kustomization.yaml.tmpl
@@ -4,6 +4,6 @@ kind: Kustomization
 resources:
   - ../../base
   - configmap.yaml
-{{- if not .GitOps }}
+{{- if not .Restricted }}
   - secret.yaml
 {{- end }}

--- a/templates/deployment/kustomize/overlays/environment/secret.yaml.tmpl
+++ b/templates/deployment/kustomize/overlays/environment/secret.yaml.tmpl
@@ -1,4 +1,4 @@
-{{- if not .GitOps }}
+{{- if not .Restricted }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/templates/factory/code/go.mod.tmpl
+++ b/templates/factory/code/go.mod.tmpl
@@ -7,7 +7,7 @@ toolchain go1.26.4
 require (
 	buf.build/go/protovalidate v1.2.0
 	connectrpc.com/connect v1.20.0
-	github.com/codefly-dev/core v0.2.52
+	github.com/codefly-dev/core v0.2.59
 	github.com/codefly-dev/sdk-go v0.1.65
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0
 	github.com/rs/cors v1.11.1

--- a/templates/factory/code/go.sum.tmpl
+++ b/templates/factory/code/go.sum.tmpl
@@ -14,8 +14,8 @@ github.com/brianvoe/gofakeit/v6 v6.28.0 h1:Xib46XXuQfmlLS2EXRuJpqcw8St6qSZz75OUo
 github.com/brianvoe/gofakeit/v6 v6.28.0/go.mod h1:Xj58BMSnFqcn/fAQeSK+/PLtC5kSb7FJIq4JyGa8vEs=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/codefly-dev/core v0.2.52 h1:bHudneVK/yLMxEc163v9Hm590E1Z6x7HWkZVdoA3CIA=
-github.com/codefly-dev/core v0.2.52/go.mod h1:hHJm+wOsHxpxKn4UMiFqBrGy0BE56iby9yptfygbdR4=
+github.com/codefly-dev/core v0.2.59 h1:uEOoYFNRf6q7unRH37cDM7ccZuQ6QTDIHnuoDfGoDnA=
+github.com/codefly-dev/core v0.2.59/go.mod h1:hHJm+wOsHxpxKn4UMiFqBrGy0BE56iby9yptfygbdR4=
 github.com/codefly-dev/sdk-go v0.1.65 h1:/AKs/XzaVW5P5VAPXSi8ZOUZHMP3N5bUq92DN6/Y2RM=
 github.com/codefly-dev/sdk-go v0.1.65/go.mod h1:IBVdaC5quw571pOELRCqZdhh6Y6pO5WE2F+jFG0EUEA=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=


### PR DESCRIPTION
Closes #48.

## Summary

- Core#110 landed (shipped in `core` v0.2.59): the plugin contract now names the neutral `RESTRICTED_PORTABLE_V1` profile instead of the GitOps-named one, and the shared rendering flag is `Restricted` rather than `GitOps`. This bumps Core and renames the deployment templates' branch variable to match, so the plugin no longer carries transport (Git/Argo/GitOps) vocabulary in its own output. The restricted branch keeps emitting secret-free manifests that reference externally managed secrets — no namespace, no inline `Secret`, digest-pinned image.
- The generated-service dependency lock (`base/code/` and the factory `go.mod`/`go.sum` templates) is bumped in lockstep with the plugin's Core version, which the repo's lock conformance test requires.
- Boundary/conformance is already enforced in CI: `TestDeploymentTemplates` runs Core's `AssertKustomizeTemplates`, which now exercises the ephemeral-local and restricted-portable contracts (plus the deprecated GitOps profile for the migration window), and CI runs it through the shared `codefly-dev/core` reusable workflow.

## Not in this PR (blocked on open dependencies)

- The dedicated **reusable manifest-only conformance workflow** (`.github#3`) does not exist yet, so there is nothing to wire into `ci.yml`. The equivalent boundary/conformance check runs today via Core's contract suite in the existing deployment test. When `.github#3` lands, the shared workflow can be adopted directly.
- The **CLI/server promotion driver** (`cli#160`) is a separate component; this plugin emits the neutral bundle it will consume and needs no plugin-specific publication code.

## Test plan

- [x] `go test . -run TestDeploymentTemplates` — restricted-portable + ephemeral-local + deprecated-GitOps contract suite passes
- [x] `go test . -run 'TestFactoryDependencyLocksMatchBase|TestBaseGeneratedServiceBuildsFromCleanModuleCache'` — generated-service lock matches and builds from a clean module cache on Core v0.2.59
- [x] `go build ./...`
- [ ] The three `TestCreateToRun*` integration tests fail locally only because the pinned `codeflydev/proto` companion image has no linux/arm64 manifest (pre-existing on `main`, unrelated to this change); they run on amd64 in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)