### PR TITLE
Use transport probes for generic deployments (#58)

### DIFF
--- a/agent.codefly.yaml
+++ b/agent.codefly.yaml
@@ -1,4 +1,4 @@
 publisher: codefly.dev
 kind: codefly:service
 name: go-grpc
-version: 0.1.26
+version: 0.1.27

--- a/deployment_test.go
+++ b/deployment_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"io/fs"
+	"strings"
 	"testing"
 
 	agenttesting "github.com/codefly-dev/core/agents/testing"
@@ -10,8 +12,22 @@ func TestDeploymentTemplates(t *testing.T) {
 	agenttesting.AssertKustomizeTemplates(t, deploymentFS, nil)
 }
 
+func TestDeploymentProbesRequireOnlyTheDeclaredListener(t *testing.T) {
+	template, err := fs.ReadFile(deploymentFS, "templates/deployment/kustomize/base/deployment.yaml.tmpl")
+	if err != nil {
+		t.Fatalf("read deployment template: %v", err)
+	}
+	source := string(template)
+	if strings.Contains(source, "/healthz") {
+		t.Fatal("generic deployment must not require a product-specific health route")
+	}
+	if count := strings.Count(source, "tcpSocket:"); count != 3 {
+		t.Fatalf("transport probes = %d, want startup, readiness, and liveness", count)
+	}
+}
+
 func TestAgentVersion(t *testing.T) {
-	if agent.Version != "0.1.26" {
-		t.Fatalf("agent version = %q, want 0.1.26", agent.Version)
+	if agent.Version != "0.1.27" {
+		t.Fatalf("agent version = %q, want 0.1.27", agent.Version)
 	}
 }

--- a/templates/deployment/kustomize/base/deployment.yaml.tmpl
+++ b/templates/deployment/kustomize/base/deployment.yaml.tmpl
@@ -74,28 +74,20 @@ spec:
             limits:
               cpu: "1"
               memory: 512Mi
-          # gRPC services that register grpc.health.v1 (which every
-          # go-grpc agent does via core/agents/agents.go's Serve)
-          # respond on either the grpc port (gRPC Check) or the http
-          # port if grpc-gateway is enabled. For broad compatibility
-          # the probes hit a /healthz HTTP path served by the
-          # grpc-gateway on the http port — that's the convention
-          # the go-grpc agent's main.go scaffold sets up.
+          # The generic deployment contract guarantees the listener,
+          # not a product-specific HTTP health route.
           startupProbe:
-            httpGet:
-              path: /healthz
+            tcpSocket:
               port: http
             periodSeconds: 2
             failureThreshold: 30
           readinessProbe:
-            httpGet:
-              path: /healthz
+            tcpSocket:
               port: http
             periodSeconds: 5
             timeoutSeconds: 3
           livenessProbe:
-            httpGet:
-              path: /healthz
+            tcpSocket:
               port: http
             periodSeconds: 30
             timeoutSeconds: 5


### PR DESCRIPTION
Closes #58.

## Summary

- Probe the listener guaranteed by the generic deployment contract instead of requiring a product-specific `/healthz` route.
- Preserve startup, readiness, and liveness timing while allowing real customized Go services to become Healthy.

## Test plan

- [x] `GOWORK=off go test ./... -run '^Test(DeploymentTemplates|DeploymentProbesRequireOnlyTheDeclaredListener|AgentVersion|FactoryDependencyLocksMatchBase|BaseGeneratedServiceBuildsFromCleanModuleCache|DockerfileTemplateCarriesModuleFixturesForWorkspaceBuilds)$' -count=1`
- [x] Regenerate Mind local GitOps and record all seven Applications Synced/Healthy in k3d.