### PR TITLE
Consume runtime endpoint allowlist enforcement

### DIFF
--- a/base/code/go.mod
+++ b/base/code/go.mod
@@ -7,7 +7,7 @@ toolchain go1.26.4
 require (
 	buf.build/go/protovalidate v1.2.0
 	connectrpc.com/connect v1.20.0
-	github.com/codefly-dev/core v0.2.63
+	github.com/codefly-dev/core v0.2.64
 	github.com/codefly-dev/sdk-go v0.1.65
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0
 	github.com/rs/cors v1.11.1

--- a/base/code/go.sum
+++ b/base/code/go.sum
@@ -28,6 +28,8 @@ github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJ
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/codefly-dev/core v0.2.63 h1:P4+a/0VHsopvKkCnw1MUUinicbW4Ax8tQvnGZE28PxM=
 github.com/codefly-dev/core v0.2.63/go.mod h1:Mbq/e8ji6kR3A4cxjz0d22ggdLv6kH6nacVIO/xpxn0=
+github.com/codefly-dev/core v0.2.64 h1:gpel9PnQEO7Naqp4ukcmIkynT91eyA8uMh0Pt7kL6gw=
+github.com/codefly-dev/core v0.2.64/go.mod h1:Mbq/e8ji6kR3A4cxjz0d22ggdLv6kH6nacVIO/xpxn0=
 github.com/codefly-dev/sdk-go v0.1.65 h1:/AKs/XzaVW5P5VAPXSi8ZOUZHMP3N5bUq92DN6/Y2RM=
 github.com/codefly-dev/sdk-go v0.1.65/go.mod h1:IBVdaC5quw571pOELRCqZdhh6Y6pO5WE2F+jFG0EUEA=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.26.4
 require (
 	buf.build/go/protovalidate v1.2.0
 	github.com/bufbuild/protocompile v0.14.1
-	github.com/codefly-dev/core v0.2.63
+	github.com/codefly-dev/core v0.2.64
 	github.com/codefly-dev/service-go v0.0.17
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/mod v0.37.0

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/codefly-dev/core v0.2.63 h1:P4+a/0VHsopvKkCnw1MUUinicbW4Ax8tQvnGZE28PxM=
 github.com/codefly-dev/core v0.2.63/go.mod h1:Mbq/e8ji6kR3A4cxjz0d22ggdLv6kH6nacVIO/xpxn0=
+github.com/codefly-dev/core v0.2.64 h1:gpel9PnQEO7Naqp4ukcmIkynT91eyA8uMh0Pt7kL6gw=
+github.com/codefly-dev/core v0.2.64/go.mod h1:Mbq/e8ji6kR3A4cxjz0d22ggdLv6kH6nacVIO/xpxn0=
 github.com/codefly-dev/gortk v0.2.0 h1:7bOlS5valYz2zil+fZctQNcPCYBcPj86abcw9N8h1hQ=
 github.com/codefly-dev/gortk v0.2.0/go.mod h1:dDWUMFgAP063OCGhTEpV7FFUj9+zTcxxO/nV80VKEwg=
 github.com/codefly-dev/service-go v0.0.17 h1:ECdwUX0mRlDsSvXg3u5YGmhVYaa/o/U89wwdn0RjLtM=

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,6 @@ github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJ
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
-github.com/codefly-dev/core v0.2.63 h1:P4+a/0VHsopvKkCnw1MUUinicbW4Ax8tQvnGZE28PxM=
-github.com/codefly-dev/core v0.2.63/go.mod h1:Mbq/e8ji6kR3A4cxjz0d22ggdLv6kH6nacVIO/xpxn0=
 github.com/codefly-dev/core v0.2.64 h1:gpel9PnQEO7Naqp4ukcmIkynT91eyA8uMh0Pt7kL6gw=
 github.com/codefly-dev/core v0.2.64/go.mod h1:Mbq/e8ji6kR3A4cxjz0d22ggdLv6kH6nacVIO/xpxn0=
 github.com/codefly-dev/gortk v0.2.0 h1:7bOlS5valYz2zil+fZctQNcPCYBcPj86abcw9N8h1hQ=

--- a/templates/factory/code/go.mod.tmpl
+++ b/templates/factory/code/go.mod.tmpl
@@ -7,7 +7,7 @@ toolchain go1.26.4
 require (
 	buf.build/go/protovalidate v1.2.0
 	connectrpc.com/connect v1.20.0
-	github.com/codefly-dev/core v0.2.63
+	github.com/codefly-dev/core v0.2.64
 	github.com/codefly-dev/sdk-go v0.1.65
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0
 	github.com/rs/cors v1.11.1

--- a/templates/factory/code/go.sum.tmpl
+++ b/templates/factory/code/go.sum.tmpl
@@ -28,6 +28,8 @@ github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJ
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/codefly-dev/core v0.2.63 h1:P4+a/0VHsopvKkCnw1MUUinicbW4Ax8tQvnGZE28PxM=
 github.com/codefly-dev/core v0.2.63/go.mod h1:Mbq/e8ji6kR3A4cxjz0d22ggdLv6kH6nacVIO/xpxn0=
+github.com/codefly-dev/core v0.2.64 h1:gpel9PnQEO7Naqp4ukcmIkynT91eyA8uMh0Pt7kL6gw=
+github.com/codefly-dev/core v0.2.64/go.mod h1:Mbq/e8ji6kR3A4cxjz0d22ggdLv6kH6nacVIO/xpxn0=
 github.com/codefly-dev/sdk-go v0.1.65 h1:/AKs/XzaVW5P5VAPXSi8ZOUZHMP3N5bUq92DN6/Y2RM=
 github.com/codefly-dev/sdk-go v0.1.65/go.mod h1:IBVdaC5quw571pOELRCqZdhh6Y6pO5WE2F+jFG0EUEA=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=


### PR DESCRIPTION
## Summary
- update the agent, generated service base, and factory lock to Core v0.2.64
- make go-grpc runtimes enforce internal endpoint module allow-lists during dependency injection

## Verification
- runtime internal-endpoint contract test
- generated base/factory dependency-lock test
- Core v0.2.64 passed 2,135/2,135 tests before release