### PR TITLE
feat: support serviceAccountName + workload-identity SA in deploy templates (#65)

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -624,6 +624,10 @@ func (s *Builder) Deploy(ctx context.Context, req *builderv0.DeploymentRequest) 
 	defer s.Wool.Catch()
 	ctx = s.Wool.Inject(ctx)
 
+	if err := s.GoGrpc.Settings.Validate(); err != nil {
+		return s.Base.Builder.DeployError(err)
+	}
+
 	return s.Base.Builder.DeployKustomize(ctx, req, services.KustomizeDeployment{
 		EnvironmentVariables: s.EnvironmentVariables,
 		Templates:            deploymentFS,

--- a/builder.go
+++ b/builder.go
@@ -616,12 +616,20 @@ func (s *Builder) Upgrade(ctx context.Context, req *builderv0.UpgradeRequest) (*
 	return s.Base.Builder.UpgradeResponse(res.Changes, res.LockfileDiff)
 }
 
-// Deploy applies the k8s manifests in templates/deployment.
+// Deploy applies the k8s manifests in templates/deployment. It mirrors
+// golanghelpers.DeployGoKubernetes but threads the service-account spec into
+// the templates so pods can run under an annotated, workload-identity SA
+// rather than the namespace default.
 func (s *Builder) Deploy(ctx context.Context, req *builderv0.DeploymentRequest) (*builderv0.DeploymentResponse, error) {
 	defer s.Wool.Catch()
 	ctx = s.Wool.Inject(ctx)
 
-	return golanghelpers.DeployGoKubernetes(ctx, s.Base.Builder, req, s.EnvironmentVariables, deploymentFS)
+	return s.Base.Builder.DeployKustomize(ctx, req, services.KustomizeDeployment{
+		EnvironmentVariables: s.EnvironmentVariables,
+		Templates:            deploymentFS,
+		Inputs:               services.ApplicationDeploymentInputs(),
+		Parameters:           s.GoGrpc.Settings.ServiceAccount,
+	})
 }
 
 // CreateEndpoints materializes gRPC / REST / Connect Endpoint resources

--- a/deployment_test.go
+++ b/deployment_test.go
@@ -51,14 +51,62 @@ func TestDeploymentServiceAccountRendering(t *testing.T) {
 }
 
 func TestDeploymentWithoutServiceAccountRendersNoSA(t *testing.T) {
-	dir := agenttesting.AssertKustomizeTemplates(t, deploymentFS, nil)
+	// Production passes a typed-nil *ServiceAccountSpec (s.GoGrpc.Settings.
+	// ServiceAccount when unset), not an untyped nil — cover both so a future
+	// guard change can't silently regress the default path.
+	for name, params := range map[string]any{
+		"untyped nil": nil,
+		"typed nil":   (*ServiceAccountSpec)(nil),
+	} {
+		t.Run(name, func(t *testing.T) {
+			dir := agenttesting.AssertKustomizeTemplates(t, deploymentFS, params)
 
-	deployment, err := os.ReadFile(filepath.Join(dir, "base", "deployment.yaml"))
-	if err != nil {
-		t.Fatalf("read deployment: %v", err)
+			deployment, err := os.ReadFile(filepath.Join(dir, "base", "deployment.yaml"))
+			if err != nil {
+				t.Fatalf("read deployment: %v", err)
+			}
+			if strings.Contains(string(deployment), "serviceAccountName:") {
+				t.Errorf("deployment must not set serviceAccountName without a spec:\n%s", deployment)
+			}
+			if _, err := os.Stat(filepath.Join(dir, "base", "serviceaccount.yaml")); err == nil {
+				if data, _ := os.ReadFile(filepath.Join(dir, "base", "serviceaccount.yaml")); strings.Contains(string(data), "kind: ServiceAccount") {
+					t.Errorf("no SA object should render without a spec:\n%s", data)
+				}
+			}
+		})
 	}
-	if strings.Contains(string(deployment), "serviceAccountName:") {
-		t.Errorf("deployment must not set serviceAccountName without a spec:\n%s", deployment)
+}
+
+func TestSettingsValidateServiceAccount(t *testing.T) {
+	tests := []struct {
+		name    string
+		sa      *ServiceAccountSpec
+		wantErr bool
+	}{
+		{name: "unset", sa: nil, wantErr: false},
+		{name: "valid", sa: &ServiceAccountSpec{Name: "db-reader"}, wantErr: false},
+		{
+			name:    "annotations without name",
+			sa:      &ServiceAccountSpec{Annotations: map[string]string{"azure.workload.identity/client-id": "x"}},
+			wantErr: true,
+		},
+		{
+			name:    "labels without name",
+			sa:      &ServiceAccountSpec{Labels: map[string]string{"azure.workload.identity/use": "true"}},
+			wantErr: true,
+		},
+		{name: "invalid dns name", sa: &ServiceAccountSpec{Name: "DB_Reader"}, wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := (&Settings{ServiceAccount: tc.sa}).Validate()
+			if tc.wantErr && err == nil {
+				t.Fatal("expected validation error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected validation error: %v", err)
+			}
+		})
 	}
 }
 

--- a/deployment_test.go
+++ b/deployment_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"io/fs"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -10,6 +12,54 @@ import (
 
 func TestDeploymentTemplates(t *testing.T) {
 	agenttesting.AssertKustomizeTemplates(t, deploymentFS, nil)
+}
+
+func TestDeploymentServiceAccountRendering(t *testing.T) {
+	spec := &ServiceAccountSpec{
+		Name:        "db-reader",
+		Annotations: map[string]string{"azure.workload.identity/client-id": "00000000-0000-0000-0000-000000000000"},
+		Labels:      map[string]string{"azure.workload.identity/use": "true"},
+	}
+	dir := agenttesting.AssertKustomizeTemplates(t, deploymentFS, spec)
+
+	deployment, err := os.ReadFile(filepath.Join(dir, "base", "deployment.yaml"))
+	if err != nil {
+		t.Fatalf("read deployment: %v", err)
+	}
+	if !strings.Contains(string(deployment), "serviceAccountName: db-reader") {
+		t.Errorf("deployment missing serviceAccountName:\n%s", deployment)
+	}
+	if !strings.Contains(string(deployment), `azure.workload.identity/use: "true"`) {
+		t.Errorf("deployment missing workload-identity pod label:\n%s", deployment)
+	}
+
+	sa, err := os.ReadFile(filepath.Join(dir, "base", "serviceaccount.yaml"))
+	if err != nil {
+		t.Fatalf("read serviceaccount: %v", err)
+	}
+	source := string(sa)
+	for _, want := range []string{
+		"kind: ServiceAccount",
+		"name: db-reader",
+		"app.kubernetes.io/managed-by: codefly",
+		`azure.workload.identity/client-id: "00000000-0000-0000-0000-000000000000"`,
+	} {
+		if !strings.Contains(source, want) {
+			t.Errorf("serviceaccount missing %q:\n%s", want, source)
+		}
+	}
+}
+
+func TestDeploymentWithoutServiceAccountRendersNoSA(t *testing.T) {
+	dir := agenttesting.AssertKustomizeTemplates(t, deploymentFS, nil)
+
+	deployment, err := os.ReadFile(filepath.Join(dir, "base", "deployment.yaml"))
+	if err != nil {
+		t.Fatalf("read deployment: %v", err)
+	}
+	if strings.Contains(string(deployment), "serviceAccountName:") {
+		t.Errorf("deployment must not set serviceAccountName without a spec:\n%s", deployment)
+	}
 }
 
 func TestDeploymentProbesRequireOnlyTheDeclaredListener(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -69,6 +69,23 @@ type Settings struct {
 	// Field named RuntimeImage (not DockerImage) to avoid colliding with
 	// services.Base.DockerImage(req).
 	RuntimeImage string `yaml:"docker-image"`
+
+	// ServiceAccount binds the workload's pods to a named Kubernetes
+	// ServiceAccount instead of the namespace default. Empty (the default)
+	// leaves pods on the default SA. See ServiceAccountSpec.
+	ServiceAccount *ServiceAccountSpec `yaml:"service-account,omitempty"`
+}
+
+// ServiceAccountSpec configures the Kubernetes ServiceAccount a service's
+// pods run under. This is the passwordless-identity seam: annotations land
+// on the rendered SA object (e.g. an Azure workload-identity client id) and
+// labels stamp the pod template (e.g. azure.workload.identity/use: "true")
+// so the identity webhook can inject the federated token. An empty Name
+// renders no SA object and leaves serviceAccountName unset.
+type ServiceAccountSpec struct {
+	Name        string            `yaml:"name"`
+	Annotations map[string]string `yaml:"annotations,omitempty"`
+	Labels      map[string]string `yaml:"labels,omitempty"`
 }
 
 func (s *Settings) Validate() error {

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"embed"
 	"fmt"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/codefly-dev/core/agents"
@@ -80,12 +81,36 @@ type Settings struct {
 // pods run under. This is the passwordless-identity seam: annotations land
 // on the rendered SA object (e.g. an Azure workload-identity client id) and
 // labels stamp the pod template (e.g. azure.workload.identity/use: "true")
-// so the identity webhook can inject the federated token. An empty Name
-// renders no SA object and leaves serviceAccountName unset.
+// so the identity webhook can inject the federated token.
 type ServiceAccountSpec struct {
 	Name        string            `yaml:"name"`
 	Annotations map[string]string `yaml:"annotations,omitempty"`
 	Labels      map[string]string `yaml:"labels,omitempty"`
+}
+
+// dns1123Subdomain matches a Kubernetes ServiceAccount name (an RFC 1123 DNS
+// subdomain).
+var dns1123Subdomain = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`)
+
+// Validate rejects a service-account block that would silently half-apply.
+// Name is mandatory whenever the block is present: annotations render only on
+// the SA object and serviceAccountName binds the pod, both keyed off Name — so
+// annotations or labels without a Name would vanish, or worse stamp the
+// workload-identity label onto a pod still running as the default SA (token
+// minting then has no identity and DB connections fail with no deploy error).
+// Requiring a valid Name keeps the SA object, serviceAccountName, and pod
+// labels consistent and fails a bad name here rather than server-side.
+func (s *ServiceAccountSpec) Validate() error {
+	if s == nil {
+		return nil
+	}
+	if s.Name == "" {
+		return fmt.Errorf("service-account requires a name when set (got annotations/labels but no name)")
+	}
+	if len(s.Name) > 253 || !dns1123Subdomain.MatchString(s.Name) {
+		return fmt.Errorf("service-account name %q must be a DNS-1123 subdomain", s.Name)
+	}
+	return nil
 }
 
 func (s *Settings) Validate() error {
@@ -100,6 +125,9 @@ func (s *Settings) Validate() error {
 		if !filepath.IsLocal(dir) || dir == "." || strings.ContainsAny(dir, "\x00\\") {
 			return fmt.Errorf("protocol output directory %q must stay below the service root", dir)
 		}
+	}
+	if err := s.ServiceAccount.Validate(); err != nil {
+		return err
 	}
 	return nil
 }

--- a/templates/deployment/kustomize/base/deployment.yaml.tmpl
+++ b/templates/deployment/kustomize/base/deployment.yaml.tmpl
@@ -13,11 +13,11 @@ spec:
       labels:
         app: {{ .Service.Name.DNSCase }}
         sha: {{ .Sha }}
-{{- with .Deployment.Parameters }}
+{{- with .Deployment.Parameters }}{{- if .Name }}
 {{- range $key, $value := .Labels }}
         {{ $key }}: {{ $value | quote }}
 {{- end }}
-{{- end }}
+{{- end }}{{- end }}
     spec:
 {{- with .Deployment.Parameters }}{{- if .Name }}
       serviceAccountName: {{ .Name }}

--- a/templates/deployment/kustomize/base/deployment.yaml.tmpl
+++ b/templates/deployment/kustomize/base/deployment.yaml.tmpl
@@ -13,7 +13,15 @@ spec:
       labels:
         app: {{ .Service.Name.DNSCase }}
         sha: {{ .Sha }}
+{{- with .Deployment.Parameters }}
+{{- range $key, $value := .Labels }}
+        {{ $key }}: {{ $value | quote }}
+{{- end }}
+{{- end }}
     spec:
+{{- with .Deployment.Parameters }}{{- if .Name }}
+      serviceAccountName: {{ .Name }}
+{{- end }}{{- end }}
       # uid 65532 = nobody/nogroup in distroless and most scratch
       # base images. The codefly Go Dockerfile template (BuildGoDocker
       # in core/runners/golang) produces a static binary on alpine,

--- a/templates/deployment/kustomize/base/kustomization.yaml.tmpl
+++ b/templates/deployment/kustomize/base/kustomization.yaml.tmpl
@@ -5,5 +5,8 @@ resources:
 {{- if not .Restricted }}
   - namespace.yaml
 {{- end }}
+{{- with .Deployment.Parameters }}{{- if .Name }}
+  - serviceaccount.yaml
+{{- end }}{{- end }}
   - deployment.yaml
   - service.yaml

--- a/templates/deployment/kustomize/base/serviceaccount.yaml.tmpl
+++ b/templates/deployment/kustomize/base/serviceaccount.yaml.tmpl
@@ -1,0 +1,15 @@
+{{- with .Deployment.Parameters }}{{- if .Name }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Name }}
+  namespace: {{ $.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: codefly
+{{- with .Annotations }}
+  annotations:
+{{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
+{{- end }}
+{{- end }}
+{{- end }}{{- end }}


### PR DESCRIPTION
Closes #65.

## Summary
- Pods rendered by the deploy templates carried no `serviceAccountName` and no workload-identity pod label, so every pod ran as the namespace `default` SA — the last-step break in the passwordless DB contract (the BeforeConnect token source needs pods running under an annotated, federated SA).
- Adds a `spec.service-account: {name, annotations, labels}` setting: renders a codefly-owned `ServiceAccount` (with the configured annotations, e.g. the Azure workload-identity client id), sets `serviceAccountName` on the pod, and stamps the configured labels onto the pod template (e.g. `azure.workload.identity/use: "true"`).
- When the setting is absent, rendered output is byte-for-byte unchanged; `automountServiceAccountToken: false` is preserved (the identity webhook injects its own projected token).

## Test plan
- [x] `go test -run TestDeployment ./...` — new `TestDeploymentServiceAccountRendering` asserts the SA object (managed-by label + annotation), `serviceAccountName`, and the pod label; `TestDeploymentWithoutServiceAccountRendersNoSA` asserts no SA leaks when unset. Both run through `AssertKustomizeTemplates`, which builds and statically validates every output profile (including restricted).
- [x] `go build ./...` / `go vet ./...` clean.
- Note: pre-existing Docker integration tests (`TestCreateToRun*`) fail in this environment because `codeflydev/proto:0.0.12` / `codeflydev/go` have no arm64 manifest — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)