### PR TITLE
test: fail loudly when proto companion image lacks host arch (#71)

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -61,6 +61,14 @@ func TestProtoImageSupportsHost(t *testing.T) {
 			isList, supportsHost := protoImageSupportsHost([]byte(tc.manifest))
 			require.Equal(t, tc.wantList, isList)
 			require.Equal(t, tc.wantSupportsHost, supportsHost)
+
+			// requireProtoCompanionImage fails the test loudly when, and only
+			// when, this predicate holds. Locking it here guards the fail-loud
+			// contract: only a manifest list that positively lacks the host arch
+			// (the amd64-only image on arm64) may block; a host-supporting list
+			// (linux/amd64 on CI) and every ambiguous shape must not.
+			blocked := isList && !supportsHost
+			require.Equal(t, tc.wantList && !tc.wantSupportsHost, blocked)
 		})
 	}
 }
@@ -119,14 +127,25 @@ func TestCreateToRunWithConnectNative(t *testing.T) {
 	}
 }
 
-// requireProtoCompanionImage skips a proto-generating integration test when the
-// pinned proto companion image is unavailable for the host platform. The image
-// is a manifest list that currently ships linux/amd64 only, so pulling it on
-// Apple Silicon fails with "no matching manifest for linux/arm64". A test is
-// skipped only when the registry manifest positively proves the host
-// architecture is absent: any ambiguity (image already built locally, manifest
-// unreadable, single-arch image) falls through so CI still fails loudly on a
-// real regression rather than silently masking one.
+// requireProtoCompanionImage fails a proto-generating integration test when the
+// pinned proto companion image cannot be obtained for the host. The image is a
+// manifest list that currently ships linux/amd64 only, so pulling it on Apple
+// Silicon fails with "no matching manifest for linux/arm64".
+//
+// We fail loudly rather than skipping, matching core's testutil.RequireProtoImage:
+// a silently-skipped integration test makes `go test ./...` report ok while the
+// create-to-run path never ran, masking regressions and letting environmental
+// drift hide bugs the test exists to catch. The remedy is in the message — build
+// the image locally for the host arch.
+//
+// Nix could in principle supply the companion on Apple Silicon, but core's
+// runners/companion.detectBackend selects Docker unconditionally whenever the
+// engine is running and never falls back, so an absent host-arch image genuinely
+// blocks proto generation. The failure therefore fires exactly when the real run
+// would fail: Docker is up but cannot get the image for this arch. Any ambiguity
+// (image already built locally, Docker/manifest unreadable — e.g. a Docker-less
+// Nix host, where detectBackend uses Nix and the run succeeds) proceeds so the
+// genuine outcome surfaces on its own terms.
 func requireProtoCompanionImage(t *testing.T, ctx context.Context) {
 	t.Helper()
 
@@ -143,18 +162,19 @@ func requireProtoCompanionImage(t *testing.T, ctx context.Context) {
 		return
 	}
 	if isList, supportsHost := protoImageSupportsHost(manifest); isList && !supportsHost {
-		t.Skipf("proto companion image %s has no linux/%s manifest; run `codefly companion build --all` to build it locally",
+		t.Fatalf("proto companion image %s has no linux/%s manifest; run `codefly companion build --all` to build it locally",
 			ref, runtime.GOARCH)
 	}
 }
 
 // protoImageSupportsHost reports whether a `docker manifest inspect` payload is a
-// multi-arch manifest list (isList) and, if so, whether it carries an entry the
-// host's Docker engine can run (supportsHost). Companion images are always
-// linux, and Docker Desktop's engine architecture matches the host, so the host
-// platform is linux/runtime.GOARCH regardless of runtime.GOOS. Attestation
-// entries (os/arch "unknown") are ignored so they count as neither a real
-// platform nor host support.
+// multi-arch manifest list (isList) and, if so, whether it carries a linux entry
+// for the host architecture (supportsHost). Companion images are linux, and a
+// default `docker pull` of a manifest list will not fall back to a non-host
+// architecture — it fails outright when the host arch is absent, rather than
+// emulating another arch — so the run needs a linux/runtime.GOARCH entry
+// regardless of runtime.GOOS. Attestation entries (os/arch "unknown") are ignored
+// so they count as neither a real platform nor host support.
 func protoImageSupportsHost(manifest []byte) (isList bool, supportsHost bool) {
 	var list struct {
 		Manifests []struct {

--- a/main_test.go
+++ b/main_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/codefly-dev/core/companions/proto"
 	agentv0 "github.com/codefly-dev/core/generated/go/codefly/services/agent/v0"
 	runtimev0 "github.com/codefly-dev/core/generated/go/codefly/services/runtime/v0"
 	"github.com/codefly-dev/core/languages"
@@ -14,7 +15,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"io"
 	"net/http"
+	"os/exec"
 	"path"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -26,6 +29,41 @@ import (
 
 	basev0 "github.com/codefly-dev/core/generated/go/codefly/base/v0"
 )
+
+func TestProtoImageSupportsHost(t *testing.T) {
+	hostList := fmt.Sprintf(
+		`{"manifests":[{"platform":{"os":"linux","architecture":%q}},{"platform":{"os":"unknown","architecture":"unknown"}}]}`,
+		runtime.GOARCH)
+	// The amd64-only proto manifest as seen from a non-amd64 host.
+	foreignArch := "amd64"
+	if runtime.GOARCH == "amd64" {
+		foreignArch = "arm64"
+	}
+	foreignList := fmt.Sprintf(
+		`{"manifests":[{"platform":{"os":"linux","architecture":%q}},{"platform":{"os":"unknown","architecture":"unknown"}}]}`,
+		foreignArch)
+
+	tests := []struct {
+		name             string
+		manifest         string
+		wantList         bool
+		wantSupportsHost bool
+	}{
+		{"host arch present", hostList, true, true},
+		{"only foreign arch", foreignList, true, false},
+		{"non-linux host arch ignored", fmt.Sprintf(`{"manifests":[{"platform":{"os":"windows","architecture":%q}}]}`, runtime.GOARCH), true, false},
+		{"attestation only", `{"manifests":[{"platform":{"os":"unknown","architecture":"unknown"}}]}`, false, false},
+		{"single arch image", `{"schemaVersion":2,"config":{}}`, false, false},
+		{"unparseable", `not json`, false, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			isList, supportsHost := protoImageSupportsHost([]byte(tc.manifest))
+			require.Equal(t, tc.wantList, isList)
+			require.Equal(t, tc.wantSupportsHost, supportsHost)
+		})
+	}
+}
 
 func TestSetRuntimeContextNixHintUsesLocalFirst(t *testing.T) {
 	ctx := context.Background()
@@ -81,9 +119,71 @@ func TestCreateToRunWithConnectNative(t *testing.T) {
 	}
 }
 
+// requireProtoCompanionImage skips a proto-generating integration test when the
+// pinned proto companion image is unavailable for the host platform. The image
+// is a manifest list that currently ships linux/amd64 only, so pulling it on
+// Apple Silicon fails with "no matching manifest for linux/arm64". A test is
+// skipped only when the registry manifest positively proves the host
+// architecture is absent: any ambiguity (image already built locally, manifest
+// unreadable, single-arch image) falls through so CI still fails loudly on a
+// real regression rather than silently masking one.
+func requireProtoCompanionImage(t *testing.T, ctx context.Context) {
+	t.Helper()
+
+	image, err := proto.CompanionImage(ctx)
+	require.NoError(t, err)
+	ref := image.Name + ":" + image.Tag
+
+	if exec.CommandContext(ctx, "docker", "image", "inspect", ref).Run() == nil {
+		return
+	}
+
+	manifest, err := exec.CommandContext(ctx, "docker", "manifest", "inspect", ref).Output()
+	if err != nil {
+		return
+	}
+	if isList, supportsHost := protoImageSupportsHost(manifest); isList && !supportsHost {
+		t.Skipf("proto companion image %s has no linux/%s manifest; run `codefly companion build --all` to build it locally",
+			ref, runtime.GOARCH)
+	}
+}
+
+// protoImageSupportsHost reports whether a `docker manifest inspect` payload is a
+// multi-arch manifest list (isList) and, if so, whether it carries an entry the
+// host's Docker engine can run (supportsHost). Companion images are always
+// linux, and Docker Desktop's engine architecture matches the host, so the host
+// platform is linux/runtime.GOARCH regardless of runtime.GOOS. Attestation
+// entries (os/arch "unknown") are ignored so they count as neither a real
+// platform nor host support.
+func protoImageSupportsHost(manifest []byte) (isList bool, supportsHost bool) {
+	var list struct {
+		Manifests []struct {
+			Platform struct {
+				OS           string `json:"os"`
+				Architecture string `json:"architecture"`
+			} `json:"platform"`
+		} `json:"manifests"`
+	}
+	if json.Unmarshal(manifest, &list) != nil {
+		return false, false
+	}
+	for _, m := range list.Manifests {
+		if m.Platform.OS == "unknown" || m.Platform.Architecture == "unknown" {
+			continue
+		}
+		isList = true
+		if m.Platform.OS == "linux" && m.Platform.Architecture == runtime.GOARCH {
+			supportsHost = true
+		}
+	}
+	return isList, supportsHost
+}
+
 func testCreateToRun(t *testing.T, runtimeContext *basev0.RuntimeContext, withConnect bool) {
 	wool.SetGlobalLogLevel(wool.DEBUG)
 	ctx := context.Background()
+
+	requireProtoCompanionImage(t, ctx)
 
 	var err error
 	tmpDir := t.TempDir()


### PR DESCRIPTION
Closes #71.

## Summary
- The three `TestCreateToRun*` integration tests were the only failures. They fail during proto generation because the proto companion image pinned in core (`codeflydev/proto:0.0.12`) is a manifest list shipping **linux/amd64 only** — on Apple Silicon, Docker refuses to pull it (`no matching manifest for linux/arm64`). CI (linux/amd64) is unaffected, which is why it stays green.
- Guard the shared `testCreateToRun` helper so it surfaces this early, **failing loudly with an actionable remedy** (`codefly companion build --all`) rather than swallowing the cryptic error buried in a sync response.
- The guard fires **only when the registry manifest positively proves the host architecture is absent** — i.e. exactly when the real run would fail, because core's `detectBackend` selects Docker unconditionally while the engine is up and never falls back to Nix. Any ambiguity (image already built locally, Docker/manifest unreadable such as a Docker-less Nix host) proceeds to a real run, so CI still exercises the full path and a genuine pull/runtime error still surfaces.

## Coverage honesty (trade-off)
An earlier revision `t.Skip`ped these tests, which made `go test ./...` print `ok` on arm64 while the create-to-run path never ran — overstating local coverage and inverting core's deliberate `testutil.RequireProtoImage` policy of failing loudly. This revision fails instead: on a fresh Apple-Silicon checkout `go test ./...` reports a clear, actionable failure until the developer builds the companion image locally for their arch (`codefly companion build --all`), after which the tests run for real and pass. The underlying cross-arch gap — core ships an amd64-only proto image and prefers Docker unconditionally — belongs in core (publish a multi-arch image, or make backend selection arch-aware).

## Test plan
- [x] On linux/amd64 (CI) the guard does not fire (manifest lists amd64); tests pull the image and run — CI green.
- [x] On darwin/arm64 the three tests fail with `proto companion image codeflydev/proto:0.0.12 has no linux/arm64 manifest; run \`codefly companion build --all\``.
- [x] `TestProtoImageSupportsHost` covers host-present, foreign-arch-only, non-linux, attestation-only, single-arch, and unparseable manifests, and locks the `isList && !supportsHost` block decision that gates the loud failure.
- [x] `gofmt -l` clean, `go vet ./...` clean, `go build ./...` clean, `go mod tidy -diff` clean.