### PR TITLE
fix: advertise only the ports a go-grpc service actually serves (#78)

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -789,10 +789,24 @@ func (s *Builder) Upgrade(ctx context.Context, req *builderv0.UpgradeRequest) (*
 	return s.Base.Builder.UpgradeResponse(res.Changes, res.LockfileDiff)
 }
 
+// DeploymentParameters carries the go-grpc-specific values the deployment
+// templates consume through .Deployment.Parameters: the optional workload
+// ServiceAccount plus which optional listeners the service serves. The http
+// (grpc-gateway) and connect listeners bind only when their endpoint is
+// enabled, so the templates emit each container/service port and probe only
+// for a port the process actually binds — a grpc-only service must not
+// advertise http, and a connect service must advertise its port.
+type DeploymentParameters struct {
+	ServiceAccount  *ServiceAccountSpec
+	RestEndpoint    bool
+	ConnectEndpoint bool
+}
+
 // Deploy applies the k8s manifests in templates/deployment. It mirrors
-// golanghelpers.DeployGoKubernetes but threads the service-account spec into
-// the templates so pods can run under an annotated, workload-identity SA
-// rather than the namespace default.
+// golanghelpers.DeployGoKubernetes but threads the service-account spec and the
+// service's declared listeners into the templates so pods can run under an
+// annotated, workload-identity SA rather than the namespace default and so the
+// manifest advertises exactly the ports the service serves.
 func (s *Builder) Deploy(ctx context.Context, req *builderv0.DeploymentRequest) (*builderv0.DeploymentResponse, error) {
 	defer s.Wool.Catch()
 	ctx = s.Wool.Inject(ctx)
@@ -805,7 +819,11 @@ func (s *Builder) Deploy(ctx context.Context, req *builderv0.DeploymentRequest) 
 		EnvironmentVariables: s.EnvironmentVariables,
 		Templates:            deploymentFS,
 		Inputs:               services.ApplicationDeploymentInputs(),
-		Parameters:           s.GoGrpc.Settings.ServiceAccount,
+		Parameters: DeploymentParameters{
+			ServiceAccount:  s.GoGrpc.Settings.ServiceAccount,
+			RestEndpoint:    s.GoGrpc.Settings.RestEndpoint,
+			ConnectEndpoint: s.GoGrpc.Settings.ConnectEndpoint,
+		},
 	})
 }
 

--- a/deployment_test.go
+++ b/deployment_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestDeploymentTemplates(t *testing.T) {
-	agenttesting.AssertKustomizeTemplates(t, deploymentFS, nil)
+	agenttesting.AssertKustomizeTemplates(t, deploymentFS, DeploymentParameters{})
 }
 
 // TestDeploymentTemplatesHaveNoOrphans catches source-level orphans: any file
@@ -54,7 +54,7 @@ func TestDeploymentTemplatesHaveNoOrphans(t *testing.T) {
 // that would slip past the source-level guard above (e.g. adding a base
 // role.yaml.tmpl without the matching `- role.yaml` entry).
 func TestDeploymentManifestsAreReferenced(t *testing.T) {
-	dir := agenttesting.AssertKustomizeTemplates(t, deploymentFS, nil)
+	dir := agenttesting.AssertKustomizeTemplates(t, deploymentFS, DeploymentParameters{})
 	// The helper renders the overlay under its environment name ("test").
 	assertManifestsReferenced(t, filepath.Join(dir, "base"))
 	assertManifestsReferenced(t, filepath.Join(dir, "overlays", "test"))
@@ -109,7 +109,7 @@ func TestDeploymentServiceAccountRendering(t *testing.T) {
 		Annotations: map[string]string{"azure.workload.identity/client-id": "00000000-0000-0000-0000-000000000000"},
 		Labels:      map[string]string{"azure.workload.identity/use": "true"},
 	}
-	dir := agenttesting.AssertKustomizeTemplates(t, deploymentFS, spec)
+	dir := agenttesting.AssertKustomizeTemplates(t, deploymentFS, DeploymentParameters{ServiceAccount: spec})
 
 	deployment, err := os.ReadFile(filepath.Join(dir, "base", "deployment.yaml"))
 	if err != nil {
@@ -140,12 +140,13 @@ func TestDeploymentServiceAccountRendering(t *testing.T) {
 }
 
 func TestDeploymentWithoutServiceAccountRendersNoSA(t *testing.T) {
-	// Production passes a typed-nil *ServiceAccountSpec (s.GoGrpc.Settings.
-	// ServiceAccount when unset), not an untyped nil — cover both so a future
+	// Production passes DeploymentParameters whose ServiceAccount is a typed-nil
+	// *ServiceAccountSpec (s.GoGrpc.Settings.ServiceAccount when unset). Cover
+	// both the zero-value parameters and an explicit typed-nil field so a future
 	// guard change can't silently regress the default path.
 	for name, params := range map[string]any{
-		"untyped nil": nil,
-		"typed nil":   (*ServiceAccountSpec)(nil),
+		"zero parameters":           DeploymentParameters{},
+		"typed-nil service account": DeploymentParameters{ServiceAccount: (*ServiceAccountSpec)(nil)},
 	} {
 		t.Run(name, func(t *testing.T) {
 			dir := agenttesting.AssertKustomizeTemplates(t, deploymentFS, params)
@@ -246,5 +247,53 @@ func TestDeploymentProbesRequireOnlyTheDeclaredListener(t *testing.T) {
 	}
 	if strings.Contains(source, "port: http") {
 		t.Fatal("probes must not target the http listener: grpc-only services never bind it")
+	}
+}
+
+// TestDeploymentPortsMatchDeclaredEndpoints pins the container/Service port set
+// to the listeners the process actually binds: grpc always, http only with the
+// REST endpoint, connect only with the Connect endpoint. A port advertised for
+// an unserved listener is the #78 failure — a Service routing to a dead port
+// and, when probed, a pod that restart-loops forever.
+func TestDeploymentPortsMatchDeclaredEndpoints(t *testing.T) {
+	type portCheck struct {
+		token   string
+		wantFor func(DeploymentParameters) bool
+	}
+	// Substrings unique to each listener's port block across deployment.yaml
+	// (containerPort) and service.yaml (Service port).
+	checks := []portCheck{
+		{"containerPort: 9090", func(DeploymentParameters) bool { return true }},
+		{"name: grpc-port", func(DeploymentParameters) bool { return true }},
+		{"containerPort: 8080", func(p DeploymentParameters) bool { return p.RestEndpoint }},
+		{"name: http-port", func(p DeploymentParameters) bool { return p.RestEndpoint }},
+		{"containerPort: 8081", func(p DeploymentParameters) bool { return p.ConnectEndpoint }},
+		{"name: connect-port", func(p DeploymentParameters) bool { return p.ConnectEndpoint }},
+	}
+	cases := map[string]DeploymentParameters{
+		"grpc only":      {},
+		"grpc + rest":    {RestEndpoint: true},
+		"grpc + connect": {ConnectEndpoint: true},
+		"all":            {RestEndpoint: true, ConnectEndpoint: true},
+	}
+	for name, params := range cases {
+		t.Run(name, func(t *testing.T) {
+			dir := agenttesting.AssertKustomizeTemplates(t, deploymentFS, params)
+			deployment, err := os.ReadFile(filepath.Join(dir, "base", "deployment.yaml"))
+			if err != nil {
+				t.Fatalf("read deployment: %v", err)
+			}
+			service, err := os.ReadFile(filepath.Join(dir, "base", "service.yaml"))
+			if err != nil {
+				t.Fatalf("read service: %v", err)
+			}
+			rendered := string(deployment) + string(service)
+			for _, check := range checks {
+				got := strings.Contains(rendered, check.token)
+				if want := check.wantFor(params); got != want {
+					t.Errorf("port token %q present=%v, want %v\n%s", check.token, got, want, rendered)
+				}
+			}
+		})
 	}
 }

--- a/deployment_test.go
+++ b/deployment_test.go
@@ -238,4 +238,13 @@ func TestDeploymentProbesRequireOnlyTheDeclaredListener(t *testing.T) {
 	if count := strings.Count(source, "tcpSocket:"); count != 3 {
 		t.Fatalf("transport probes = %d, want startup, readiness, and liveness", count)
 	}
+	// grpc is the only listener every service serves; http (grpc-gateway) and
+	// connect bind only when those endpoints are enabled. Probing http would
+	// restart-loop any grpc-only service, so every probe must target grpc.
+	if count := strings.Count(source, "port: grpc"); count != 3 {
+		t.Fatalf("probes targeting the grpc listener = %d, want all three (startup, readiness, liveness)", count)
+	}
+	if strings.Contains(source, "port: http") {
+		t.Fatal("probes must not target the http listener: grpc-only services never bind it")
+	}
 }

--- a/templates/deployment/kustomize/base/deployment.yaml.tmpl
+++ b/templates/deployment/kustomize/base/deployment.yaml.tmpl
@@ -82,21 +82,25 @@ spec:
             limits:
               cpu: "1"
               memory: 512Mi
-          # The generic deployment contract guarantees the listener,
-          # not a product-specific HTTP health route.
+          # The generic deployment contract guarantees the listener, not a
+          # product-specific HTTP health route. Probe grpc, not http: the gRPC
+          # listener is the one endpoint every service serves, while the http
+          # (grpc-gateway) and connect listeners only bind when those endpoints
+          # are enabled. A grpc-only service never binds http, so probing it
+          # fails startup forever and the kubelet restart-loops the pod.
           startupProbe:
             tcpSocket:
-              port: http
+              port: grpc
             periodSeconds: 2
             failureThreshold: 30
           readinessProbe:
             tcpSocket:
-              port: http
+              port: grpc
             periodSeconds: 5
             timeoutSeconds: 3
           livenessProbe:
             tcpSocket:
-              port: http
+              port: grpc
             periodSeconds: 30
             timeoutSeconds: 5
             failureThreshold: 3

--- a/templates/deployment/kustomize/base/deployment.yaml.tmpl
+++ b/templates/deployment/kustomize/base/deployment.yaml.tmpl
@@ -13,13 +13,13 @@ spec:
       labels:
         app: {{ .Service.Name.DNSCase }}
         sha: {{ .Sha }}
-{{- with .Deployment.Parameters }}{{- if .Name }}
+{{- with .Deployment.Parameters.ServiceAccount }}{{- if .Name }}
 {{- range $key, $value := .Labels }}
         {{ $key }}: {{ $value | quote }}
 {{- end }}
 {{- end }}{{- end }}
     spec:
-{{- with .Deployment.Parameters }}{{- if .Name }}
+{{- with .Deployment.Parameters.ServiceAccount }}{{- if .Name }}
       serviceAccountName: {{ .Name }}
 {{- end }}{{- end }}
       # uid 65532 = nobody/nogroup in distroless and most scratch
@@ -50,12 +50,20 @@ spec:
             seccompProfile:
               type: RuntimeDefault
           ports:
-            # Match service.yaml.tmpl. http is grpc-gateway (REST
-            # facade), grpc is the raw gRPC listener.
-            - name: http
-              containerPort: 8080
+            # Match service.yaml.tmpl. grpc is the raw gRPC listener, always
+            # served. http (grpc-gateway REST facade) and connect bind only
+            # when their endpoint is enabled — advertise a port only when the
+            # process binds it, so nothing routes to a dead port.
             - name: grpc
               containerPort: 9090
+{{- if .Deployment.Parameters.RestEndpoint }}
+            - name: http
+              containerPort: 8080
+{{- end }}
+{{- if .Deployment.Parameters.ConnectEndpoint }}
+            - name: connect
+              containerPort: 8081
+{{- end }}
           envFrom:
             - configMapRef:
                 name: cm-{{ .Service.Name.DNSCase }}

--- a/templates/deployment/kustomize/base/kustomization.yaml.tmpl
+++ b/templates/deployment/kustomize/base/kustomization.yaml.tmpl
@@ -5,7 +5,7 @@ resources:
 {{- if not .Restricted }}
   - namespace.yaml
 {{- end }}
-{{- with .Deployment.Parameters }}{{- if .Name }}
+{{- with .Deployment.Parameters.ServiceAccount }}{{- if .Name }}
   - serviceaccount.yaml
 {{- end }}{{- end }}
   - deployment.yaml

--- a/templates/deployment/kustomize/base/service.yaml.tmpl
+++ b/templates/deployment/kustomize/base/service.yaml.tmpl
@@ -8,10 +8,18 @@ spec:
     app: {{ .Service.Name.DNSCase}}
   ports:
     - protocol: TCP
-      name: http-port
-      port: 8080
-      targetPort: 8080
-    - protocol: TCP
       name: grpc-port
       port: 9090
       targetPort: 9090
+{{- if .Deployment.Parameters.RestEndpoint }}
+    - protocol: TCP
+      name: http-port
+      port: 8080
+      targetPort: 8080
+{{- end }}
+{{- if .Deployment.Parameters.ConnectEndpoint }}
+    - protocol: TCP
+      name: connect-port
+      port: 8081
+      targetPort: 8081
+{{- end }}

--- a/templates/deployment/kustomize/base/serviceaccount.yaml.tmpl
+++ b/templates/deployment/kustomize/base/serviceaccount.yaml.tmpl
@@ -1,4 +1,4 @@
-{{- with .Deployment.Parameters }}{{- if .Name }}
+{{- with .Deployment.Parameters.ServiceAccount }}{{- if .Name }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
Closes #78.

## Summary

- **Root cause:** the deployment and Service manifests hardcoded a fixed `http` (8080) + `grpc` (9090) port pair regardless of which endpoints a service declared, and the `connect` listener (8081) was never exposed at all. The generated manifest advertised ports the process doesn't bind and omitted one it does.
- **grpc-only services** (issue #78) advertised an `http` port nothing binds; the Service routed 8080 to a dead port and all three probes dialed it, so the kubelet failed startup forever and restart-looped the pod while logs looked healthy.
- **Connect-enabled services** hit the mirror-image bug: they bind 8081 but neither the container ports nor the Service exposed it, so Connect traffic could never reach the pod through the Service.
- **Fix:** thread the service's declared listeners (`RestEndpoint` / `ConnectEndpoint`) through `DeploymentParameters` alongside the existing `ServiceAccount`, and emit each container/Service port — and the probes — only for a port the process actually binds: `grpc` always, `http` with the REST endpoint, `connect` with the Connect endpoint. Probes target `grpc`, the one listener every service serves.

## Test plan

- [x] `TestDeploymentPortsMatchDeclaredEndpoints` — renders grpc-only / +rest / +connect / all and asserts the container and Service port set matches exactly the declared listeners
- [x] `TestDeploymentProbesRequireOnlyTheDeclaredListener` — all three probes target `grpc`, none target `http`
- [x] `TestDeploymentServiceAccountRendering` / `TestDeploymentWithoutServiceAccountRendersNoSA` updated for the nested `.ServiceAccount` parameter and still green
- [x] `go build ./...`, `go vet ./...`, and the full package test suite (`go test . -short`) pass