### PR TITLE
chore: update Go toolchain to 1.27

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/codefly-dev/service-go-grpc
 
-go 1.25.12
-
-toolchain go1.26.6
+go 1.27.0
 
 require (
 	buf.build/go/protovalidate v1.3.0


### PR DESCRIPTION
Fleet-wide Go 1.27 bump: `go 1.27.0` (implies `toolchain go1.27.0`) + CI `setup-go` 1.27.0, `go mod tidy`. Local verify: **build_ok** on go1.27.0. CI validates the rest.