### PR TITLE
chore: bump core to v0.3.8 (Go 1.27) (#452)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,13 +1,11 @@
 module github.com/codefly-dev/service-go-grpc
 
-go 1.25.12
-
-toolchain go1.26.6
+go 1.27.0
 
 require (
 	buf.build/go/protovalidate v1.3.0
 	github.com/bufbuild/protocompile v0.14.1
-	github.com/codefly-dev/core v0.3.6
+	github.com/codefly-dev/core v0.3.8
 	github.com/codefly-dev/service-go v0.0.34
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/mod v0.40.0

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,8 @@ github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJ
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/cloudflare/circl v1.6.5 h1:O64F26HEqNhznd/hrC5KZXVKYuKM2rx4deZDTc4ihQA=
 github.com/cloudflare/circl v1.6.5/go.mod h1:h5LNyxAc5nTue9DS5jT+48en2PSDYt3zdGnz5OstK6c=
-github.com/codefly-dev/core v0.3.6 h1:lt5EyL+uS1Z6Vzg+V/HhpnIV43Lu5rN9E0k+ZslIKHk=
-github.com/codefly-dev/core v0.3.6/go.mod h1:ca5IAJnFJSC3OPl5DcoRIi41BMfO0As8BaDGciYZ7nI=
+github.com/codefly-dev/core v0.3.8 h1:iqXrad1zwpX1CzAKr53TeuYLWHV8B5QkhHVV6unb9Os=
+github.com/codefly-dev/core v0.3.8/go.mod h1:4V8BP4F5mnRDZvylhC9P5N7rfifpAma5n3dW4YD+gtQ=
 github.com/codefly-dev/gortk v0.2.0 h1:7bOlS5valYz2zil+fZctQNcPCYBcPj86abcw9N8h1hQ=
 github.com/codefly-dev/gortk v0.2.0/go.mod h1:dDWUMFgAP063OCGhTEpV7FFUj9+zTcxxO/nV80VKEwg=
 github.com/codefly-dev/service-go v0.0.34 h1:6pFibtZrG0mtqGUqlJnVmI+jpjcPR0Tgepx3HOP1lAE=


### PR DESCRIPTION
Part of codefly-dev/cli#452.

## Summary

- Bump `github.com/codefly-dev/core` v0.3.6 → v0.3.8 so this agent repo aligns with the CLI (codefly-dev/cli#451) on the same core contract.
- core v0.3.8 targets Go 1.27, so the module's `go` directive moves to `go 1.27.0` (the older `toolchain` pin is dropped — the go line now matches).

No workflow or `Makefile` change is needed: this repo's CI runs the core reusable `go-service-ci.yml` (build / vet / `go mod tidy -diff` / test) with `go-version-file: go.mod`, so it has no golangci-lint step. The golangci-lint fix described in the tracking issue applies only to the cli repo (which owns a standalone lint job + Makefile), not to the service repos.

## Test plan

- [x] `go build ./...` clean (under Go 1.27)
- [x] `go vet ./...` clean
- [x] `go mod tidy` leaves only go.mod + go.sum changed
- [ ] CI green on the epic branch base