### PR TITLE
fix: gate generated gRPC reflection behind codefly.IsLocal() (#86)

### DIFF
--- a/base/code/pkg/adapters/grpc_gen.go
+++ b/base/code/pkg/adapters/grpc_gen.go
@@ -99,7 +99,9 @@ func NewGrpServer(c *Configuration) (*GrpcServer, error) {
 		service = c.Service
 	}
 	gen.RegisterWebServiceServer(grpcServer, service)
-	reflection.Register(grpcServer)
+	if codefly.IsLocal() {
+		reflection.Register(grpcServer)
+	}
 	return &s, nil
 }
 

--- a/proto_template_test.go
+++ b/proto_template_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"go/format"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -99,6 +100,31 @@ func TestFactoryDependencyLocksMatchBase(t *testing.T) {
 	agentCore := dependencyLine(agentMod, "github.com/codefly-dev/core")
 	if generatedCore == "" || generatedCore != agentCore {
 		t.Fatalf("generated core dependency %q does not match agent dependency %q", generatedCore, agentCore)
+	}
+}
+
+// TestFactoryGrpcAdapterMatchesBase binds the generated gRPC bootstrap in base/
+// to its factory template. Only go.mod/go.sum were previously drift-checked, so
+// changing the reflection gate (or any other logic) in one copy but not the
+// other would slip through CI as long as it still compiled. This makes such a
+// divergence fail the build instead.
+func TestFactoryGrpcAdapterMatchesBase(t *testing.T) {
+	baseGrpc, err := os.ReadFile("base/code/pkg/adapters/grpc_gen.go")
+	if err != nil {
+		t.Fatalf("read base gRPC adapter: %v", err)
+	}
+	templateGrpc, err := factoryFS.ReadFile("templates/factory/code/pkg/adapters/grpc_gen.go.tmpl")
+	if err != nil {
+		t.Fatalf("read factory gRPC adapter template: %v", err)
+	}
+	rendered := bytes.ReplaceAll(templateGrpc, []byte("{{ .Service.Name.Title }}"), []byte("Web"))
+	rendered = bytes.ReplaceAll(rendered, []byte("{{ .Service.Name.DNSCase }}"), []byte("codefly-base"))
+	formatted, err := format.Source(rendered)
+	if err != nil {
+		t.Fatalf("format rendered gRPC adapter: %v", err)
+	}
+	if !bytes.Equal(baseGrpc, formatted) {
+		t.Fatal("factory gRPC adapter template drifted from base/code/pkg/adapters/grpc_gen.go")
 	}
 }
 

--- a/proto_template_test.go
+++ b/proto_template_test.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -274,6 +275,26 @@ func TestGeneratedServiceRegistersHealthChecks(t *testing.T) {
 		if !strings.Contains(string(restTemplate), want) {
 			t.Errorf("REST adapter template does not contain %q", want)
 		}
+	}
+}
+
+// TestGeneratedServiceGatesReflectionBehindIsLocal keeps gRPC server
+// reflection — which enumerates every registered service and message for any
+// unauthenticated caller — a local-only discovery aid, so deployed services do
+// not disclose their API shape as needless attack surface.
+func TestGeneratedServiceGatesReflectionBehindIsLocal(t *testing.T) {
+	grpcTemplate, err := factoryFS.ReadFile("templates/factory/code/pkg/adapters/grpc_gen.go.tmpl")
+	if err != nil {
+		t.Fatalf("read gRPC adapter template: %v", err)
+	}
+	content := string(grpcTemplate)
+
+	gated := regexp.MustCompile(`if codefly\.IsLocal\(\) \{\s*reflection\.Register\(grpcServer\)\s*\}`)
+	if !gated.MatchString(content) {
+		t.Error("gRPC adapter template does not gate reflection registration behind codefly.IsLocal()")
+	}
+	if strings.Count(content, "reflection.Register(grpcServer)") != 1 {
+		t.Error("gRPC adapter template registers reflection outside the codefly.IsLocal() gate")
 	}
 }
 

--- a/templates/factory/code/pkg/adapters/grpc_gen.go.tmpl
+++ b/templates/factory/code/pkg/adapters/grpc_gen.go.tmpl
@@ -99,7 +99,9 @@ func NewGrpServer(c *Configuration) (*GrpcServer, error) {
 		service = c.Service
 	}
 	gen.Register{{ .Service.Name.Title }}ServiceServer(grpcServer, service)
-	reflection.Register(grpcServer)
+	if codefly.IsLocal() {
+		reflection.Register(grpcServer)
+	}
 	return &s, nil
 }
 


### PR DESCRIPTION
Closes #86.

## Summary
- Server reflection enumerates every registered service and message for any unauthenticated caller — fine as a local discovery aid, but needless API-shape disclosure in a deployed environment.
- The generated gRPC bootstrap registered reflection unconditionally, and downstream modules can't patch `grpc_gen.go` (it's regenerated and guarded by the drift gate). Gating it at the source template applies the fix everywhere with no downstream change.

## Test plan
- [x] `TestGeneratedServiceGatesReflectionBehindIsLocal` asserts the template registers reflection only inside the `codefly.IsLocal()` gate (present under IsLocal, absent otherwise).
- [x] `go test` generator suite passes (template/base drift, scaffold, health checks).
- [x] `base/code` golden fixture regenerated to match, `gofmt`-clean, and builds (`go build ./...`).