### PR TITLE
fix: default generated REST CORS to a non-wildcard policy (#88)

### DIFF
--- a/base/code/pkg/adapters/cors_gen.go
+++ b/base/code/pkg/adapters/cors_gen.go
@@ -1,7 +1,6 @@
 package adapters
 
 import (
-	"fmt"
 	"github.com/rs/cors"
 )
 
@@ -12,10 +11,8 @@ import (
 ----------------------------------------------------------------- */
 
 func Cors() *cors.Cors {
-	fmt.Println("setting up cors: TODO")
 	return cors.New(cors.Options{
-		AllowedOrigins: []string{"*"},
-		AllowedMethods: []string{"GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"},
-		AllowedHeaders: []string{"*"},
+		AllowOriginFunc: func(string) bool { return false },
+		AllowedMethods:  []string{"GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"},
 	})
 }

--- a/builder.go
+++ b/builder.go
@@ -158,6 +158,13 @@ func (s *Builder) Sync(ctx context.Context, request *builderv0.SyncRequest) (*bu
 		return s.Base.Builder.SyncError(err)
 	}
 	if len(scaffoldTargets) > 0 {
+		// Regenerating the REST adapter replaces any older, wildcard-open CORS
+		// policy with the same-origin default. That silently blocks cross-origin
+		// callers a service may have depended on, so surface the change and the
+		// opt-in rather than letting it fail only in the browser.
+		if s.GoGrpc.Settings.RestEndpoint && s.GoGrpc.Settings.Cors.DeniesCrossOrigin() {
+			s.Wool.Warn("REST CORS defaults to same-origin: the regenerated adapter refuses all cross-origin requests. Set cors.allowed-origins or cors.allow-all in settings to permit cross-origin access.")
+		}
 		create := CreateConfiguration{Information: s.Information, Settings: s.GoGrpc.Settings, Envs: []string{}}
 		generated := services.WithFactory(factoryFS).
 			WithPathSelect(generatedScaffoldSelect()).

--- a/deployment_test.go
+++ b/deployment_test.go
@@ -211,8 +211,23 @@ func TestSettingsValidateCors(t *testing.T) {
 		{name: "allow all", cors: CorsSpec{AllowAll: true}, wantErr: false},
 		{name: "wildcard origin", cors: CorsSpec{AllowedOrigins: []string{"*"}}, wantErr: true},
 		{
+			name:    "allowlist with headers",
+			cors:    CorsSpec{AllowedOrigins: []string{"https://app.example.com"}, AllowedHeaders: []string{"Authorization"}},
+			wantErr: false,
+		},
+		{
 			name:    "allow all with allowlist",
 			cors:    CorsSpec{AllowAll: true, AllowedOrigins: []string{"https://app.example.com"}},
+			wantErr: true,
+		},
+		{
+			name:    "allow all with headers",
+			cors:    CorsSpec{AllowAll: true, AllowedHeaders: []string{"Authorization"}},
+			wantErr: true,
+		},
+		{
+			name:    "headers without origins",
+			cors:    CorsSpec{AllowedHeaders: []string{"Authorization"}},
 			wantErr: true,
 		},
 	}
@@ -224,6 +239,25 @@ func TestSettingsValidateCors(t *testing.T) {
 			}
 			if !tc.wantErr && err != nil {
 				t.Fatalf("unexpected validation error: %v", err)
+			}
+		})
+	}
+}
+
+func TestCorsSpecDeniesCrossOrigin(t *testing.T) {
+	tests := []struct {
+		name string
+		cors CorsSpec
+		want bool
+	}{
+		{name: "zero value", cors: CorsSpec{}, want: true},
+		{name: "allow all", cors: CorsSpec{AllowAll: true}, want: false},
+		{name: "allowlist", cors: CorsSpec{AllowedOrigins: []string{"https://app.example.com"}}, want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.cors.DeniesCrossOrigin(); got != tc.want {
+				t.Fatalf("DeniesCrossOrigin() = %v, want %v", got, tc.want)
 			}
 		})
 	}

--- a/deployment_test.go
+++ b/deployment_test.go
@@ -200,6 +200,35 @@ func TestSettingsValidateServiceAccount(t *testing.T) {
 	}
 }
 
+func TestSettingsValidateCors(t *testing.T) {
+	tests := []struct {
+		name    string
+		cors    CorsSpec
+		wantErr bool
+	}{
+		{name: "empty", cors: CorsSpec{}, wantErr: false},
+		{name: "allowlist", cors: CorsSpec{AllowedOrigins: []string{"https://app.example.com"}}, wantErr: false},
+		{name: "allow all", cors: CorsSpec{AllowAll: true}, wantErr: false},
+		{name: "wildcard origin", cors: CorsSpec{AllowedOrigins: []string{"*"}}, wantErr: true},
+		{
+			name:    "allow all with allowlist",
+			cors:    CorsSpec{AllowAll: true, AllowedOrigins: []string{"https://app.example.com"}},
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := (&Settings{Cors: tc.cors}).Validate()
+			if tc.wantErr && err == nil {
+				t.Fatal("expected validation error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected validation error: %v", err)
+			}
+		})
+	}
+}
+
 func TestSettingsValidateRuntimeAssets(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/main.go
+++ b/main.go
@@ -87,8 +87,9 @@ type Settings struct {
 
 	// Cors drives the generated REST listener's cross-origin policy. The zero
 	// value (no `cors:` block) denies every cross-origin request — a
-	// same-origin default. See CorsSpec.
-	Cors CorsSpec `yaml:"cors,omitempty"`
+	// same-origin default. See CorsSpec. No omitempty: a struct value is never
+	// "empty" to the YAML encoder, so the tag would be a silent no-op.
+	Cors CorsSpec `yaml:"cors"`
 }
 
 // CorsSpec drives the CORS policy baked into the generated REST adapter
@@ -113,20 +114,42 @@ type CorsSpec struct {
 	AllowAll bool `yaml:"allow-all,omitempty"`
 }
 
-// Validate rejects a CORS block that would silently widen access. A literal
-// "*" origin is refused so the wildcard cannot slip in as an allowlist entry —
-// it must go through AllowAll — and AllowAll cannot be combined with an
-// allowlist that it would silently ignore.
+// Validate rejects a CORS block that would silently widen access or silently
+// drop configuration. A literal "*" origin is refused so the wildcard cannot
+// slip in as an allowlist entry — it must go through AllowAll. Any field the
+// generated adapter would ignore is a hard error rather than a no-op, because a
+// setting that vanishes is worse than one that fails loudly.
 func (c CorsSpec) Validate() error {
 	for _, origin := range c.AllowedOrigins {
 		if origin == "*" {
 			return fmt.Errorf(`cors: use allow-all instead of a "*" allowed-origins entry`)
 		}
 	}
-	if c.AllowAll && len(c.AllowedOrigins) > 0 {
-		return fmt.Errorf("cors: allow-all cannot be combined with allowed-origins")
+	if c.AllowAll {
+		// allow-all is the "everything" policy; the generated adapter emits a
+		// wildcard and ignores any allowlist, so a supplied one would silently
+		// vanish. Reject the combination instead.
+		if len(c.AllowedOrigins) > 0 || len(c.AllowedHeaders) > 0 {
+			return fmt.Errorf("cors: allow-all cannot be combined with allowed-origins or allowed-headers")
+		}
+		return nil
+	}
+	// A header allowlist only takes effect alongside an origin allowlist. With
+	// no origins the policy denies every cross-origin request and the configured
+	// headers would never reach the generated adapter — fail rather than drop.
+	if len(c.AllowedHeaders) > 0 && len(c.AllowedOrigins) == 0 {
+		return fmt.Errorf("cors: allowed-headers requires allowed-origins")
 	}
 	return nil
+}
+
+// DeniesCrossOrigin reports whether this spec resolves to the default
+// same-origin policy — no explicit allowlist and no allow-all opt-in — under
+// which the generated adapter refuses every cross-origin request. It gates the
+// Sync-time warning that flags this behavior change to services regenerating an
+// older, wildcard-open adapter.
+func (c CorsSpec) DeniesCrossOrigin() bool {
+	return !c.AllowAll && len(c.AllowedOrigins) == 0
 }
 
 // ServiceAccountSpec configures the Kubernetes ServiceAccount a service's

--- a/main.go
+++ b/main.go
@@ -84,6 +84,49 @@ type Settings struct {
 	// ServiceAccount instead of the namespace default. Empty (the default)
 	// leaves pods on the default SA. See ServiceAccountSpec.
 	ServiceAccount *ServiceAccountSpec `yaml:"service-account,omitempty"`
+
+	// Cors drives the generated REST listener's cross-origin policy. The zero
+	// value (no `cors:` block) denies every cross-origin request — a
+	// same-origin default. See CorsSpec.
+	Cors CorsSpec `yaml:"cors,omitempty"`
+}
+
+// CorsSpec drives the CORS policy baked into the generated REST adapter
+// (pkg/adapters/cors_gen.go). That file is agent-owned and must not be edited
+// by hand, so cross-origin access is configured here instead. The zero value
+// is a same-origin policy: every cross-origin request is refused.
+type CorsSpec struct {
+	// AllowedOrigins is the exact cross-origin allowlist. Empty (the default)
+	// refuses every cross-origin request; same-origin traffic is unaffected.
+	// A literal "*" is rejected by Validate — reach for AllowAll instead so the
+	// wildcard is a deliberate, greppable choice rather than an allowlist typo.
+	AllowedOrigins []string `yaml:"allowed-origins,omitempty"`
+
+	// AllowedHeaders overrides the request headers a cross-origin caller may
+	// send. Empty falls back to the rs/cors safe defaults (Accept,
+	// Content-Type, X-Requested-With).
+	AllowedHeaders []string `yaml:"allowed-headers,omitempty"`
+
+	// AllowAll restores the permissive wildcard policy (any origin, any
+	// header). It is the documented dev-mode escape hatch; anything reachable
+	// beyond localhost should carry an explicit AllowedOrigins allowlist.
+	AllowAll bool `yaml:"allow-all,omitempty"`
+}
+
+// Validate rejects a CORS block that would silently widen access. A literal
+// "*" origin is refused so the wildcard cannot slip in as an allowlist entry —
+// it must go through AllowAll — and AllowAll cannot be combined with an
+// allowlist that it would silently ignore.
+func (c CorsSpec) Validate() error {
+	for _, origin := range c.AllowedOrigins {
+		if origin == "*" {
+			return fmt.Errorf(`cors: use allow-all instead of a "*" allowed-origins entry`)
+		}
+	}
+	if c.AllowAll && len(c.AllowedOrigins) > 0 {
+		return fmt.Errorf("cors: allow-all cannot be combined with allowed-origins")
+	}
+	return nil
 }
 
 // ServiceAccountSpec configures the Kubernetes ServiceAccount a service's
@@ -141,6 +184,9 @@ func (s *Settings) Validate() error {
 		}
 	}
 	if err := s.ServiceAccount.Validate(); err != nil {
+		return err
+	}
+	if err := s.Cors.Validate(); err != nil {
 		return err
 	}
 	return nil

--- a/proto_template_test.go
+++ b/proto_template_test.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"text/template"
 )
 
 // TestProtoTemplatePinsGoPackage prevents a versioned protobuf namespace from
@@ -125,6 +126,74 @@ func TestFactoryGrpcAdapterMatchesBase(t *testing.T) {
 	}
 	if !bytes.Equal(baseGrpc, formatted) {
 		t.Fatal("factory gRPC adapter template drifted from base/code/pkg/adapters/grpc_gen.go")
+	}
+}
+
+func renderCorsTemplate(t *testing.T, settings *Settings) string {
+	t.Helper()
+	raw, err := factoryFS.ReadFile("templates/factory/code/pkg/adapters/cors_gen.go.tmpl")
+	if err != nil {
+		t.Fatalf("read cors adapter template: %v", err)
+	}
+	tmpl, err := template.New("cors").Parse(string(raw))
+	if err != nil {
+		t.Fatalf("parse cors adapter template: %v", err)
+	}
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, CreateConfiguration{Settings: settings}); err != nil {
+		t.Fatalf("execute cors adapter template: %v", err)
+	}
+	formatted, err := format.Source(buf.Bytes())
+	if err != nil {
+		t.Fatalf("format rendered cors adapter: %v\n%s", err, buf.String())
+	}
+	return string(formatted)
+}
+
+// TestFactoryCorsAdapterMatchesBase keeps the checked-in base adapter equal to
+// the template's default (no `cors:` block) rendering, so the safe same-origin
+// default cannot silently drift back toward the old wildcard placeholder.
+func TestFactoryCorsAdapterMatchesBase(t *testing.T) {
+	baseCors, err := os.ReadFile("base/code/pkg/adapters/cors_gen.go")
+	if err != nil {
+		t.Fatalf("read base cors adapter: %v", err)
+	}
+	rendered := renderCorsTemplate(t, &Settings{})
+	if rendered != string(baseCors) {
+		t.Fatalf("factory cors adapter template drifted from base/code/pkg/adapters/cors_gen.go\n--- rendered ---\n%s", rendered)
+	}
+}
+
+// TestGeneratedServiceCorsIsConfigurable pins the CORS contract: fresh services
+// default to a non-wildcard same-origin policy, an allowlist is baked from
+// settings, and allow-all restores the permissive wildcard escape hatch.
+func TestGeneratedServiceCorsIsConfigurable(t *testing.T) {
+	def := renderCorsTemplate(t, &Settings{})
+	if strings.Contains(def, `"*"`) {
+		t.Errorf("default CORS policy ships a wildcard:\n%s", def)
+	}
+	if !strings.Contains(def, "AllowOriginFunc: func(string) bool { return false }") {
+		t.Errorf("default CORS policy does not deny cross-origin requests:\n%s", def)
+	}
+
+	allowlisted := renderCorsTemplate(t, &Settings{Cors: CorsSpec{
+		AllowedOrigins: []string{"https://app.example.com"},
+		AllowedHeaders: []string{"Authorization"},
+	}})
+	for _, want := range []string{`"https://app.example.com"`, `"Authorization"`} {
+		if !strings.Contains(allowlisted, want) {
+			t.Errorf("configured CORS value %q not baked into policy:\n%s", want, allowlisted)
+		}
+	}
+	if strings.Contains(allowlisted, `"*"`) {
+		t.Errorf("allowlisted CORS policy leaked a wildcard:\n%s", allowlisted)
+	}
+
+	permissive := renderCorsTemplate(t, &Settings{Cors: CorsSpec{AllowAll: true}})
+	for _, want := range []string{`AllowedOrigins: []string{"*"}`, `AllowedHeaders: []string{"*"}`} {
+		if !strings.Contains(permissive, want) {
+			t.Errorf("allow-all CORS policy missing %q:\n%s", want, permissive)
+		}
 	}
 }
 

--- a/proto_template_test.go
+++ b/proto_template_test.go
@@ -10,7 +10,8 @@ import (
 	"regexp"
 	"strings"
 	"testing"
-	"text/template"
+
+	"github.com/codefly-dev/core/templates"
 )
 
 // TestProtoTemplatePinsGoPackage prevents a versioned protobuf namespace from
@@ -129,23 +130,24 @@ func TestFactoryGrpcAdapterMatchesBase(t *testing.T) {
 	}
 }
 
+// renderCorsTemplate renders the CORS adapter template through the same core
+// engine (templates.ApplyTemplate) the generation pipeline uses, so the test
+// exercises its funcMap — including the quote helper the template relies on to
+// escape configured origins/headers — rather than a bare text/template that
+// would silently diverge from production.
 func renderCorsTemplate(t *testing.T, settings *Settings) string {
 	t.Helper()
 	raw, err := factoryFS.ReadFile("templates/factory/code/pkg/adapters/cors_gen.go.tmpl")
 	if err != nil {
 		t.Fatalf("read cors adapter template: %v", err)
 	}
-	tmpl, err := template.New("cors").Parse(string(raw))
+	rendered, err := templates.ApplyTemplate(string(raw), CreateConfiguration{Settings: settings})
 	if err != nil {
-		t.Fatalf("parse cors adapter template: %v", err)
+		t.Fatalf("apply cors adapter template: %v", err)
 	}
-	var buf bytes.Buffer
-	if err := tmpl.Execute(&buf, CreateConfiguration{Settings: settings}); err != nil {
-		t.Fatalf("execute cors adapter template: %v", err)
-	}
-	formatted, err := format.Source(buf.Bytes())
+	formatted, err := format.Source([]byte(rendered))
 	if err != nil {
-		t.Fatalf("format rendered cors adapter: %v\n%s", err, buf.String())
+		t.Fatalf("format rendered cors adapter: %v\n%s", err, rendered)
 	}
 	return string(formatted)
 }
@@ -187,6 +189,15 @@ func TestGeneratedServiceCorsIsConfigurable(t *testing.T) {
 	}
 	if strings.Contains(allowlisted, `"*"`) {
 		t.Errorf("allowlisted CORS policy leaked a wildcard:\n%s", allowlisted)
+	}
+
+	// An origin carrying a quote/backslash must be escaped into the generated Go
+	// string literal, not spliced in raw — otherwise the generated service fails
+	// to compile. renderCorsTemplate fails on invalid Go, so reaching the assert
+	// already proves the render is well-formed.
+	escaped := renderCorsTemplate(t, &Settings{Cors: CorsSpec{AllowedOrigins: []string{`https://a"b\c`}}})
+	if !strings.Contains(escaped, `"https://a\"b\\c"`) {
+		t.Errorf("origin was not safely quoted into generated policy:\n%s", escaped)
 	}
 
 	permissive := renderCorsTemplate(t, &Settings{Cors: CorsSpec{AllowAll: true}})

--- a/templates/agent/README.md.tmpl
+++ b/templates/agent/README.md.tmpl
@@ -70,5 +70,6 @@ codefly test service
 | `debug-symbols` | Include debug symbols in binary |
 | `race-condition-detection-run` | Enable Go race detector |
 | `rest-endpoint` | Generate REST gateway alongside gRPC |
+| `cors` | REST cross-origin policy: `allowed-origins` allowlist, optional `allowed-headers`, `allow-all` dev escape hatch (defaults to same-origin) |
 | `with-cgo` | Enable CGO for native dependencies |
 | `with-workspace` | Use Go workspace mode |

--- a/templates/factory/code/pkg/adapters/cors_gen.go.tmpl
+++ b/templates/factory/code/pkg/adapters/cors_gen.go.tmpl
@@ -1,7 +1,6 @@
 package adapters
 
 import (
-	"fmt"
 	"github.com/rs/cors"
 )
 
@@ -12,10 +11,28 @@ import (
 ----------------------------------------------------------------- */
 
 func Cors() *cors.Cors {
-	fmt.Println("setting up cors: TODO")
 	return cors.New(cors.Options{
+{{- if .Settings.Cors.AllowAll }}
 		AllowedOrigins: []string{"*"},
 		AllowedMethods: []string{"GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"},
 		AllowedHeaders: []string{"*"},
+{{- else if .Settings.Cors.AllowedOrigins }}
+		AllowedOrigins: []string{
+{{- range .Settings.Cors.AllowedOrigins }}
+			"{{ . }}",
+{{- end }}
+		},
+		AllowedMethods: []string{"GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"},
+{{- if .Settings.Cors.AllowedHeaders }}
+		AllowedHeaders: []string{
+{{- range .Settings.Cors.AllowedHeaders }}
+			"{{ . }}",
+{{- end }}
+		},
+{{- end }}
+{{- else }}
+		AllowOriginFunc: func(string) bool { return false },
+		AllowedMethods:  []string{"GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"},
+{{- end }}
 	})
 }

--- a/templates/factory/code/pkg/adapters/cors_gen.go.tmpl
+++ b/templates/factory/code/pkg/adapters/cors_gen.go.tmpl
@@ -19,14 +19,14 @@ func Cors() *cors.Cors {
 {{- else if .Settings.Cors.AllowedOrigins }}
 		AllowedOrigins: []string{
 {{- range .Settings.Cors.AllowedOrigins }}
-			"{{ . }}",
+			{{ . | quote }},
 {{- end }}
 		},
 		AllowedMethods: []string{"GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"},
 {{- if .Settings.Cors.AllowedHeaders }}
 		AllowedHeaders: []string{
 {{- range .Settings.Cors.AllowedHeaders }}
-			"{{ . }}",
+			{{ . | quote }},
 {{- end }}
 		},
 {{- end }}


### PR DESCRIPTION
Closes #88.

## Summary

- Generated services shipped a hard-coded permissive REST CORS policy (`AllowedOrigins: ["*"]`, `AllowedHeaders: ["*"]`) behind a `TODO` placeholder, so every service answered cross-origin reads from any origin on its whole REST surface.
- The policy is now driven by a `cors:` settings block: an explicit `allowed-origins` allowlist, optional `allowed-headers`, and an `allow-all` dev escape hatch that restores the old wildcard behavior verbatim.
- With no `cors:` block, the generated `Cors()` refuses every cross-origin request while leaving same-origin traffic untouched — a safe same-origin default rather than `*`.

## Details

- `rs/cors` treats an empty `AllowedOrigins` as allow-all, so the default rendering denies origins explicitly via `AllowOriginFunc: func(string) bool { return false }` instead of an empty list.
- `CorsSpec.Validate` rejects a literal `"*"` allowlist entry (steering intent through `allow-all`) and refuses `allow-all` combined with an allowlist it would silently ignore.
- `base/code/pkg/adapters/cors_gen.go` is updated to the new default rendering; a new test pins the template's default output equal to `base/` so the safe default can't drift back to the wildcard placeholder.

## Test plan

- [x] `go test ./...` (full suite, incl. base module build from a clean cache)
- [x] `TestGeneratedServiceCorsIsConfigurable` — default is non-wildcard/deny-all, allowlist is baked from settings, `allow-all` restores the wildcard
- [x] `TestFactoryCorsAdapterMatchesBase` — template default rendering equals the checked-in `base/` adapter
- [x] `TestSettingsValidateCors` — wildcard-in-allowlist and allow-all+allowlist are rejected
- [x] `go vet .`

🤖 Generated with [Claude Code](https://claude.com/claude-code)