### PR TITLE
fix(mcp): own the MCP gRPC forwarding connection lifecycle (#89)

### DIFF
--- a/base/code/pkg/adapters/mcp_gen.go
+++ b/base/code/pkg/adapters/mcp_gen.go
@@ -50,24 +50,26 @@ var mcpAllowedMethods = []string{
 type MCPServer struct {
 	config *Configuration
 	server *http.Server
+	conn   *grpc.ClientConn
 }
 
 func NewMCPServer(c *Configuration) (*MCPServer, error) {
+	opts := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
+	conn, err := grpc.NewClient(fmt.Sprintf("0.0.0.0:%d", c.EndpointGrpcPort), opts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create MCP gRPC client connection: %w", err)
+	}
 	return &MCPServer{
 		config: c,
 		server: &http.Server{Addr: fmt.Sprintf(":%d", *c.EndpointMcpPort)},
+		conn:   conn,
 	}, nil
 }
 
 func (s *MCPServer) Run(_ context.Context) error {
 	fmt.Println("Starting MCP server at", *s.config.EndpointMcpPort)
 
-	opts := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
-	conn, err := grpc.NewClient(fmt.Sprintf("0.0.0.0:%d", s.config.EndpointGrpcPort), opts...)
-	if err != nil {
-		return fmt.Errorf("failed to create MCP gRPC client connection: %w", err)
-	}
-	mcpHandler, err := NewMCPHandler(conn)
+	mcpHandler, err := NewMCPHandler(s.conn)
 	if err != nil {
 		return fmt.Errorf("failed to build MCP handler: %w", err)
 	}
@@ -82,8 +84,14 @@ func (s *MCPServer) Run(_ context.Context) error {
 	return nil
 }
 
+// Shutdown stops the HTTP listener and closes the gRPC client connection that
+// tool calls are forwarded over, so the connection does not outlive the server.
 func (s *MCPServer) Shutdown(ctx context.Context) error {
-	return s.server.Shutdown(ctx)
+	err := s.server.Shutdown(ctx)
+	if connErr := s.conn.Close(); connErr != nil && err == nil {
+		err = connErr
+	}
+	return err
 }
 
 // MCPRouter dispatches MCPPath (and its subpaths) to the MCP handler and every

--- a/proto_template_test.go
+++ b/proto_template_test.go
@@ -409,6 +409,68 @@ func TestGeneratedServiceServesMcpOnDedicatedPort(t *testing.T) {
 	}
 }
 
+// TestGeneratedServiceServesMcpWithoutRest pins the headline acceptance of #89:
+// mcp-endpoint no longer requires rest-endpoint. It renders the wiring templates
+// with MCP on and REST off and asserts the output is valid Go that wires the
+// dedicated MCP server while omitting REST entirely — the combination that
+// riding the REST listener made impossible.
+func TestGeneratedServiceServesMcpWithoutRest(t *testing.T) {
+	render := func(name string) string {
+		content, err := factoryFS.ReadFile(name)
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		type nameParts struct{ DNSCase, Title, CamelCase string }
+		ctx := struct {
+			Service  struct{ Name nameParts }
+			Settings struct {
+				RestEndpoint    bool
+				ConnectEndpoint bool
+				McpEndpoint     bool
+				McpMethods      []string
+			}
+		}{}
+		ctx.Service.Name = nameParts{DNSCase: "codefly-base", Title: "Web", CamelCase: "web"}
+		ctx.Settings.McpEndpoint = true
+		ctx.Settings.McpMethods = []string{"api.WebService/Version"}
+
+		tmpl, err := template.New("factory").Parse(string(content))
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		var buf bytes.Buffer
+		if err := tmpl.Execute(&buf, ctx); err != nil {
+			t.Fatalf("execute %s: %v", name, err)
+		}
+		// format.Source parses the render; it fails on any stray ungated REST
+		// reference or broken MCP wiring left behind when REST is disabled.
+		if _, err := format.Source(buf.Bytes()); err != nil {
+			t.Fatalf("%s rendered invalid Go with mcp-on/rest-off: %v\n%s", name, err, buf.String())
+		}
+		return buf.String()
+	}
+
+	server := render("templates/factory/code/pkg/adapters/server_gen.go.tmpl")
+	for _, want := range []string{"mcp     *MCPServer", "NewMCPServer(config)", "server.mcp.Run(ctx)", "server.mcp.Shutdown(ctx)"} {
+		if !strings.Contains(server, want) {
+			t.Errorf("server adapter (mcp on, rest off) does not wire MCP: missing %q", want)
+		}
+	}
+	for _, unexpected := range []string{"RestServer", "NewRestServer", "server.rest"} {
+		if strings.Contains(server, unexpected) {
+			t.Errorf("server adapter (rest off) still references REST: %q", unexpected)
+		}
+	}
+
+	mainGo := render("templates/factory/code/main.go.tmpl")
+	if !strings.Contains(mainGo, "config.EndpointMcpPort") {
+		t.Error("main (mcp on) does not read the dedicated MCP port")
+	}
+	if strings.Contains(mainGo, "EndpointHttpPort") {
+		t.Error("main (rest off) still reads the REST port")
+	}
+}
+
 // TestGeneratedServiceRegistersHealthChecks keeps the grpc.health.v1 service
 // and the /healthz gateway route that the kustomize deployment probes target.
 func TestGeneratedServiceRegistersHealthChecks(t *testing.T) {

--- a/templates/factory/code/pkg/adapters/mcp_gen.go.tmpl
+++ b/templates/factory/code/pkg/adapters/mcp_gen.go.tmpl
@@ -53,24 +53,26 @@ var mcpAllowedMethods = []string{
 type MCPServer struct {
 	config *Configuration
 	server *http.Server
+	conn   *grpc.ClientConn
 }
 
 func NewMCPServer(c *Configuration) (*MCPServer, error) {
+	opts := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
+	conn, err := grpc.NewClient(fmt.Sprintf("0.0.0.0:%d", c.EndpointGrpcPort), opts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create MCP gRPC client connection: %w", err)
+	}
 	return &MCPServer{
 		config: c,
 		server: &http.Server{Addr: fmt.Sprintf(":%d", *c.EndpointMcpPort)},
+		conn:   conn,
 	}, nil
 }
 
 func (s *MCPServer) Run(_ context.Context) error {
 	fmt.Println("Starting MCP server at", *s.config.EndpointMcpPort)
 
-	opts := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
-	conn, err := grpc.NewClient(fmt.Sprintf("0.0.0.0:%d", s.config.EndpointGrpcPort), opts...)
-	if err != nil {
-		return fmt.Errorf("failed to create MCP gRPC client connection: %w", err)
-	}
-	mcpHandler, err := NewMCPHandler(conn)
+	mcpHandler, err := NewMCPHandler(s.conn)
 	if err != nil {
 		return fmt.Errorf("failed to build MCP handler: %w", err)
 	}
@@ -85,8 +87,14 @@ func (s *MCPServer) Run(_ context.Context) error {
 	return nil
 }
 
+// Shutdown stops the HTTP listener and closes the gRPC client connection that
+// tool calls are forwarded over, so the connection does not outlive the server.
 func (s *MCPServer) Shutdown(ctx context.Context) error {
-	return s.server.Shutdown(ctx)
+	err := s.server.Shutdown(ctx)
+	if connErr := s.conn.Close(); connErr != nil && err == nil {
+		err = connErr
+	}
+	return err
 }
 
 // MCPRouter dispatches MCPPath (and its subpaths) to the MCP handler and every


### PR DESCRIPTION
Follow-up hardening on top of #91 (which implemented #89 on the `mcp`
integration branch). Targets `mcp`, not `main`, because that is where the MCP
feature currently lives — `main` has no MCP code yet. This does **not** close
#89: the issue will close when `mcp` merges to `main`.

## Summary

- `MCPServer` created its gRPC forwarding connection as a local in `Run` and
  never closed it — `Shutdown` only stopped the HTTP listener, so the
  connection outlived every server stop (a leak carried over from when MCP
  rode the REST listener). Give `MCPServer` ownership: create the connection
  in `NewMCPServer`, store it, and close it in `Shutdown`. Setting it at
  construction (before `Start` spawns the `Run` goroutine) makes `Shutdown`
  race-free; `grpc.NewClient` is lazy, so dial timing is unchanged.
- Pin the headline #89 acceptance — `mcp-endpoint` works without
  `rest-endpoint` — with a generation test that renders the wiring templates
  with MCP on and REST off and asserts the output is valid Go that wires the
  dedicated MCP server while omitting REST entirely. It was previously only
  covered indirectly.

Both the base fixture (`base/code/...`) and the factory template are edited in
lockstep, as `TestFactoryMcpAdapterMatchesBase` requires.

## Test plan

- [x] `go build ./...` + `go vet ./...` clean (root and `base/code`)
- [x] `go test .` template/deployment/settings/generation suites green, incl. new `TestGeneratedServiceServesMcpWithoutRest`
- [x] `go test ./pkg/adapters/` green in `base/code`
- [x] `TestFactoryMcpAdapterMatchesBase` confirms base ↔ template parity
- [x] `gofmt`/`go vet` clean on touched files; no new `golangci-lint` findings on changed lines
- [ ] Docker-backed `testCreateToRun` integration path not run locally (amd64-only proto image on this arm64 host); covered by CI